### PR TITLE
feat: pass a custom title to ZkInsertLink during execution

### DIFF
--- a/lua/zk/commands/builtin.lua
+++ b/lua/zk/commands/builtin.lua
@@ -76,9 +76,13 @@ local function insert_link(selected, opts)
 
   local location = util.get_lsp_location_from_selection()
   local selected_text = util.get_text_in_range(util.get_selected_range())
+  local custom_title = ""
 
   if not selected then
     location = util.get_lsp_location_from_caret()
+    if opts["title"] then
+      custom_title = opts["title"]
+    end
   else
     if opts["matchSelected"] then
       opts = vim.tbl_extend("force", { match = { selected_text } }, opts or {})
@@ -89,6 +93,10 @@ local function insert_link(selected, opts)
     assert(note ~= nil, "Picker failed before link insertion: note is nil")
 
     local link_opts = {}
+
+    if selected ~= nil then
+      link_opts.title = custom_title
+    end
 
     if selected and selected_text ~= nil then
       link_opts.title = selected_text

--- a/lua/zk/commands/builtin.lua
+++ b/lua/zk/commands/builtin.lua
@@ -94,7 +94,7 @@ local function insert_link(selected, opts)
 
     local link_opts = {}
 
-    if selected ~= nil then
+    if not selected and custom_title ~= "" then
       link_opts.title = custom_title
     end
 


### PR DESCRIPTION
Currently, when inserting a link with `ZkInsertLink`, a markdown link is returned with a blank title, and the cursor residing at the end of the inserted link.

eg:

```text
Here, and inserted link: [](path)| <-- cursor
```

This requires the user to navigate backwards, which isn't so optimal and can break the flow of writing.

This PR therefore adds the option to pass a title via a table to the `ZkInsertLink` command (in keeping with the same syntax present throughout the API).

`ZkInsertLink {title = "custom title"}` will therefore result in, the picker opening, and after selection of a note:

```text
Here, and inserted link: [custom title](path)| <-- cursor
```


I see this is a beneficial use case, and as an *alternative* to `[[` completion because there are many times where we know we want to link to something, by using an alternate title.

eg:

> `[There are multiple reasons](/research/list-of-reasons.md)` to accept this PR.

> I wrote about that `[yesterday](/diaries/...)`

This also negates the need to first write a phrase, highlight that phrase and execute `ZkInsertLinkAtSelection`, which is of course still a good option, but it's an extra step if we already know what we want to write.

This would also of course enable such a keybind:
```lua
-- insert a link with custom title (or leave blank)
vim.keymap.set("n", "<leader>zl", ":ZkInsertLink {title = vim.fn.input('Link text: ')}<cr>") 
```

