### PR TITLE
Add support for `mini.pick` as a picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Via [lazy.nvim](https://github.com/folke/lazy.nvim)
 }
 ```
 
-To get the best experience, it's recommended to also install either [Telescope](https://github.com/nvim-telescope/telescope.nvim) or [fzf](https://github.com/junegunn/fzf).
+To get the best experience, it's recommended to also install either [Telescope](https://github.com/nvim-telescope/telescope.nvim), [fzf](https://github.com/junegunn/fzf), or [mini.pick](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-pick.md)
 
 ## Setup
 
@@ -74,8 +74,8 @@ require("zk").setup()
 **The default configuration**
 ```lua
 require("zk").setup({
-  -- can be "telescope", "fzf", "fzf_lua" or "select" (`vim.ui.select`)
-  -- it's recommended to use "telescope", "fzf" or "fzf_lua"
+  -- can be "telescope", "fzf", "fzf_lua", "minipick", or "select" (`vim.ui.select`)
+  -- it's recommended to use "telescope", "fzf", "fzf_lua", or "minipick"
   picker = "select",
 
   lsp = {

--- a/doc/zk.txt
+++ b/doc/zk.txt
@@ -44,7 +44,7 @@ Via vim-plug (https://github.com/junegunn/vim-plug)
     Plug "zk-org/zk-nvim"
 <
 
-To get the best experience, it's recommended to also install either Telescope (https://github.com/nvim-telescope/telescope.nvim) or fzf (https://github.com/junegunn/fzf).
+To get the best experience, it's recommended to also install either Telescope (https://github.com/nvim-telescope/telescope.nvim), fzf (https://github.com/junegunn/fzf), or mini.pick (https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-pick.md).
 
 --------------------------------------------------------------------------------
 SETUP                                                                   *zk-setup*
@@ -58,8 +58,8 @@ SETUP                                                                   *zk-setu
 The default configuration
 >
     require("zk").setup({
-      -- can be "telescope", "fzf", "fzf_lua" or "select" (`vim.ui.select`)
-      -- it's recommended to use "telescope", "fzf" or "fzf_lua"
+      -- can be "telescope", "fzf", "fzf_lua", "minipick", or "select" (`vim.ui.select`)
+      -- it's recommended to use "telescope", "fzf", "fzf_lua", or "minipick"
       picker = "select",
       lsp = {
         -- `config` is passed to `vim.lsp.start_client(config)`

--- a/lua/zk/pickers/minipick.lua
+++ b/lua/zk/pickers/minipick.lua
@@ -5,8 +5,9 @@ local minipick = require("mini.pick")
 M.note_picker_list_api_selection = { "title", "path", "absPath" }
 
 M.show_note_picker = function(notes, opts, cb)
-  notes = vim.tbl_map(function(n)
-    return { text = n.title, path = n.absPath, note = n }
+  notes = vim.tbl_map(function(note)
+    local title = note.title or note.path
+    return { text = title, path = note.absPath, note = note }
   end, notes)
 
   opts = opts or {}

--- a/lua/zk/pickers/minipick.lua
+++ b/lua/zk/pickers/minipick.lua
@@ -7,65 +7,69 @@ M.note_picker_list_api_selection = { "title", "path", "absPath" }
 M.show_note_picker = function(notes, opts, cb)
   notes = vim.tbl_map(function(note)
     local title = note.title or note.path
-    return { text = title, path = note.absPath, note = note }
+    return { text = title, path = note.absPath, value = note }
   end, notes)
-
-  opts = opts or {}
-  local minipick_opts = vim.tbl_deep_extend("force", {
-    source = {
-      items = notes,
-      name = opts.title,
-      choose = function(_)
-        return nil
-      end,
-    },
-    window = {
-      prompt_prefix = opts.title .. "> ",
-    },
-  }, opts.minipick or {})
-
-  local item = minipick.start(minipick_opts)
-  if item ~= nil then
-    cb(opts.multi_select and { item.note } or item.note)
-  end
+  H.item_picker(notes, opts, cb)
 end
 
 M.show_tag_picker = function(tags, opts, cb)
-  tags = vim.tbl_map(function(t)
-    local padded_cnt = H.ensure_text_width(t.note_count, opts.note_count_width or 4)
+  local width = H.max_note_count(tags)
+  tags = vim.tbl_map(function(tag)
+    local padded_count = H.pad(tag.note_count, width)
     return {
-      text = string.format("%s │ %s", padded_cnt, t.name),
-      tag = t,
+      text = string.format(" %s │ %s", padded_count, tag.name),
+      value = tag,
     }
   end, tags)
+  H.item_picker(tags, opts, cb)
+end
 
+H.item_picker = function(items, opts, cb)
   opts = opts or {}
   local minipick_opts = vim.tbl_deep_extend("force", {
-    source = {
-      items = tags,
-      name = opts.title,
-      choose = function(_)
-        return nil
-      end,
-    },
     window = {
       prompt_prefix = opts.title .. "> ",
     },
+    source = {
+      items = items,
+      name = opts.title,
+
+      choose = function(selected_item) -- item guaranteed to be non-nil
+        local target_window = minipick.get_picker_state().windows.target
+        vim.api.nvim_win_call(target_window, function()
+          cb(opts.multi_select and { selected_item.value } or selected_item.value)
+        end)
+        return nil
+      end,
+
+      choose_marked = function(selected_items) -- could be empty table
+        if opts.multi_select and not vim.tbl_isempty(selected_items) then
+          local target_window = minipick.get_picker_state().windows.target
+          vim.api.nvim_win_call(target_window, function()
+            cb(vim.tbl_map(function(item)
+              return item.value
+            end, selected_items))
+          end)
+        end
+        return nil
+      end,
+    },
   }, opts.minipick or {})
 
-  local item = minipick.start(minipick_opts)
-  if item ~= nil then
-    cb(opts.multi_select and { item.tag } or item.tag)
-  end
+  minipick.start(minipick_opts)
 end
 
--- From mini.extras
-H.ensure_text_width = function(text, width)
-  local text_width = vim.fn.strchars(text)
-  if text_width <= width then
-    return string.rep(" ", width - text_width) .. text
+H.max_note_count = function(tags)
+  local max_count = 0
+  for _, t in ipairs(tags) do
+    max_count = math.max(max_count, t.note_count)
   end
-  return "…" .. vim.fn.strcharpart(text, text_width - width + 1, width - 1)
+  return vim.fn.strchars(tostring(max_count))
+end
+
+H.pad = function(text, width)
+  local text_width = vim.fn.strchars(text)
+  return string.rep(" ", width - text_width) .. text
 end
 
 return M

--- a/lua/zk/pickers/minipick.lua
+++ b/lua/zk/pickers/minipick.lua
@@ -1,0 +1,73 @@
+local M = {}
+local H = {}
+local minipick = require("mini.pick")
+
+-- Picker from zk-nvim must implement this.
+M.note_picker_list_api_selection = { "title", "path", "absPath" }
+
+-- Picker from zk-nvim must implement this.
+M.show_note_picker = function(notes, opts, cb)
+  notes = vim.tbl_map(function(n)
+    return { text = n.title, path = n.absPath, note = n }
+  end, notes)
+
+  opts = opts or {}
+  local minipick_opts = vim.tbl_deep_extend("force", {
+    source = {
+      items = notes,
+      name = opts.title,
+      choose = function(_)
+        return nil
+      end,
+    },
+    window = {
+      prompt_prefix = opts.title .. "> ",
+    },
+  }, opts.minipick or {})
+
+  local item = minipick.start(minipick_opts)
+  if item ~= nil then
+    cb(opts.multi_select and { item.note } or item.note)
+  end
+end
+
+-- Picker from zk-nvim must implement this.
+M.show_tag_picker = function(tags, opts, cb)
+  tags = vim.tbl_map(function(t)
+    local padded_cnt = H.ensure_text_width(t.note_count, opts.note_count_width or 4)
+    return {
+      text = string.format("%s │ %s", padded_cnt, t.name),
+      tag = t,
+    }
+  end, tags)
+
+  opts = opts or {}
+  local minipick_opts = vim.tbl_deep_extend("force", {
+    source = {
+      items = tags,
+      name = opts.title,
+      choose = function(_)
+        return nil
+      end,
+    },
+    window = {
+      prompt_prefix = opts.title .. "> ",
+    },
+  }, opts.minipick or {})
+
+  local item = minipick.start(minipick_opts)
+  if item ~= nil then
+    cb(opts.multi_select and { item.tag } or item.tag)
+  end
+end
+
+-- From mini.extras
+H.ensure_text_width = function(text, width)
+  local text_width = vim.fn.strchars(text)
+  if text_width <= width then
+    return string.rep(" ", width - text_width) .. text
+  end
+  return "…" .. vim.fn.strcharpart(text, text_width - width + 1, width - 1)
+end
+
+return M

--- a/lua/zk/pickers/minipick.lua
+++ b/lua/zk/pickers/minipick.lua
@@ -2,10 +2,8 @@ local M = {}
 local H = {}
 local minipick = require("mini.pick")
 
--- Picker from zk-nvim must implement this.
 M.note_picker_list_api_selection = { "title", "path", "absPath" }
 
--- Picker from zk-nvim must implement this.
 M.show_note_picker = function(notes, opts, cb)
   notes = vim.tbl_map(function(n)
     return { text = n.title, path = n.absPath, note = n }
@@ -31,7 +29,6 @@ M.show_note_picker = function(notes, opts, cb)
   end
 end
 
--- Picker from zk-nvim must implement this.
 M.show_tag_picker = function(tags, opts, cb)
   tags = vim.tbl_map(function(t)
     local padded_cnt = H.ensure_text_width(t.note_count, opts.note_count_width or 4)


### PR DESCRIPTION
With [mini](https://github.com/echasnovski/mini.nvim/tree/main) gaining in popularity, this commit adds support for [mini.pick](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-pick.md).

Here is a short screencast showing this new picker in action with Zk notes:

https://github.com/zk-org/zk-nvim/assets/747855/cf645482-c3eb-4713-8925-bb1501f54cb8

