### PR TITLE
fix(doc): add vim modeline to properly show the help

### DIFF
--- a/doc/zk.txt
+++ b/doc/zk.txt
@@ -490,3 +490,5 @@ It's possible (but unnecessary) to also load the notes and tags pickers as a tel
     :Telescope zk tags created=today
 <
 
+==============================================================================
+ vim:tw=78:ts=8:ft=help:norl:fdm=marker:cole=2:


### PR DESCRIPTION
Without this modeline, when I run `:help zk-zk-nvim`, the filetype is
txt (text), not help.
