### PR TITLE
support nvim v0.10.0 lsp api change (get_clients)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,12 @@
 # zk-nvim
+
 Neovim extension for the [`zk`](https://github.com/zk-org/zk) plain text note-taking assistant.
-
-## News: We Are In Maintenance Mode
-
-> [!IMPORTANT] 
-> As of January 2nd, the original brain behind zk, [Mickaël
-> Menu](https://github.com/mickael-menu), made the difficult decision to retire
-> from zk and the suite of programs supporting it. He put out a [call for
-> maintainers](https://github.com/zk-org/zk/discussions/371), which has
-> garnerned enough response to enable the project to continue! So zk is
-> definitely still here for you.
-> E.g., [kabouzeid](https://github.com/kabouzeid) who conceived the `zk-nvim` 
-> plugin has signed up as a maintainer too, which is excellent!
->
-> During this transition phase, we are placing the project into a maintenance
-> mode, which means we are going to address existing issues and any teething
-> problems with transferring the code bases to the new
-> [zk-org](https://github.com/zk-org) organisation, which is where you can now
-> find all the related projects. It also gives us new maintainers the space to
-> get up to speed with the code base, which will help us address new issues and
-> feature requests when they come.
->
-> So for now, feel free to lodge new issues, but please withold on feature
-> requests until we are out of maintenance mode. This will help keep our issues
-> boards concise and pr's easier to manage.
->
-> The [call to maintainers](https://github.com/zk-org/zk/discussions/371) is
-> still open. Please comment there if you feel commited enough to come onboard!
-> PR's, ideas, discussions and conversations are still and always will be
-> warmly welcomed, with or without 'maintainer' status ❤️
 
 ## Requirements
 
 | `zk-nvim` | `zk`   | Neovim |
 |-----------|--------|--------|
-| latest    | 0.13.0 | 0.8.0  |
+| latest    | >=0.13.0 | >=0.8.0  |
 
 ## Installation
 

--- a/lua/zk/lsp.lua
+++ b/lua/zk/lsp.lua
@@ -11,7 +11,12 @@ function M.external_client()
     client_name = "zk"
   end
 
-  local active_clients = vim.lsp.get_active_clients({ name = client_name })
+  local active_clients = {}
+  if vim.fn.has("nvim-0.10") then
+    active_clients = vim.lsp.get_clients({ name = client_name })
+  else
+    active_clients = vim.lsp.get_active_clients({ name = client_name })
+  end
 
   if active_clients == {} then
     return nil


### PR DESCRIPTION
resolves #165.

lsp nvim <=0.9 -> 0.10: `get_active_clients` -> `get_clients`.
