### PR TITLE
Zk Grep

### DIFF
--- a/lua/zk.lua
+++ b/lua/zk.lua
@@ -100,8 +100,8 @@ end
 function M.pick_notes(options, picker_options, cb)
   options = vim.tbl_extend("force", { select = ui.get_pick_notes_list_api_selection(picker_options) }, options or {})
 
-  if options["grep"] ~= nil then
-    picker_options["grep"] = true
+  if options.grep then
+    picker_options.grep = options.grep
     ui.pick_notes({}, picker_options, cb)
   else
     api.list(options.notebook_path, options, function(err, notes)

--- a/lua/zk.lua
+++ b/lua/zk.lua
@@ -99,10 +99,16 @@ end
 ---@see zk.ui.pick_notes
 function M.pick_notes(options, picker_options, cb)
   options = vim.tbl_extend("force", { select = ui.get_pick_notes_list_api_selection(picker_options) }, options or {})
-  api.list(options.notebook_path, options, function(err, notes)
-    assert(not err, tostring(err))
-    ui.pick_notes(notes, picker_options, cb)
-  end)
+
+  if options["grep"] ~= nil then
+    picker_options["grep"] = true
+    ui.pick_notes({}, picker_options, cb)
+  else
+    api.list(options.notebook_path, options, function(err, notes)
+      assert(not err, tostring(err))
+      ui.pick_notes(notes, picker_options, cb)
+    end)
+  end
 end
 
 ---Opens a tags picker, and calls the callback with the selection

--- a/lua/zk/commands/builtin.lua
+++ b/lua/zk/commands/builtin.lua
@@ -61,6 +61,13 @@ commands.add("ZkNotes", function(options)
   zk.edit(options, { title = "Zk Notes" })
 end)
 
+commands.add("ZkGrep", function(options)
+  -- Insert an option to grep the notes
+  -- TODO: insert rather than overwrite
+  options = {grep=true}
+  zk.edit(options, { title = "Zk Grep" })
+end)
+
 commands.add("ZkBacklinks", function(options)
   options = vim.tbl_extend("force", { linkTo = { vim.api.nvim_buf_get_name(0) } }, options or {})
   zk.edit(options, { title = "Zk Backlinks" })

--- a/lua/zk/commands/builtin.lua
+++ b/lua/zk/commands/builtin.lua
@@ -62,9 +62,8 @@ commands.add("ZkNotes", function(options)
 end)
 
 commands.add("ZkGrep", function(options)
-  -- Insert an option to grep the notes
-  -- TODO: insert rather than overwrite
-  options = {grep=true}
+  options = options or {}
+  options.grep = true
   zk.edit(options, { title = "Zk Grep" })
 end)
 

--- a/lua/zk/pickers/telescope.lua
+++ b/lua/zk/pickers/telescope.lua
@@ -72,6 +72,7 @@ function M.show_note_picker(notes, options, cb)
       sorter = conf.file_sorter(options),
       previewer = M.make_note_previewer(),
       attach_mappings = function(prompt_bufnr)
+        -- TODO: add an action here to grep the currently displayed notes with ZkGrep.
         actions.select_default:replace(function()
           if options.multi_select then
             local selection = {}

--- a/lua/zk/ui.lua
+++ b/lua/zk/ui.lua
@@ -11,11 +11,11 @@ function M.pick_notes(notes, options, cb)
   options =
     vim.tbl_extend("force", { title = "Zk Notes", picker = config.options.picker, multi_select = true }, options or {})
 
-  if options.picker ~= "telescope" then
-    print(":ZkGrep is only usable with Telescope for now. Maybe time for a PR? 😘")
-    return
-  end
   if options.grep ~= nil then
+    if options.picker ~= "telescope" then
+      print(":ZkGrep is only usable with Telescope for now. Maybe time for a PR? 😘")
+      return
+    end
     require("zk.pickers." .. options.picker).show_note_grep_picker(options, cb)
   else
     require("zk.pickers." .. options.picker).show_note_picker(notes, options, cb)

--- a/lua/zk/ui.lua
+++ b/lua/zk/ui.lua
@@ -11,7 +11,7 @@ function M.pick_notes(notes, options, cb)
   options =
     vim.tbl_extend("force", { title = "Zk Notes", picker = config.options.picker, multi_select = true }, options or {})
 
-  if options["grep"] ~= nil then
+  if options.grep ~= nil then
     require("zk.pickers." .. options.picker).show_note_grep_picker(options, cb)
   else
     require("zk.pickers." .. options.picker).show_note_picker(notes, options, cb)

--- a/lua/zk/ui.lua
+++ b/lua/zk/ui.lua
@@ -10,7 +10,12 @@ local M = {}
 function M.pick_notes(notes, options, cb)
   options =
     vim.tbl_extend("force", { title = "Zk Notes", picker = config.options.picker, multi_select = true }, options or {})
-  require("zk.pickers." .. options.picker).show_note_picker(notes, options, cb)
+
+  if options["grep"] ~= nil then
+    require("zk.pickers." .. options.picker).show_note_grep_picker(options, cb)
+  else
+    require("zk.pickers." .. options.picker).show_note_picker(notes, options, cb)
+  end
 end
 
 ---Opens a tags picker

--- a/lua/zk/ui.lua
+++ b/lua/zk/ui.lua
@@ -11,6 +11,10 @@ function M.pick_notes(notes, options, cb)
   options =
     vim.tbl_extend("force", { title = "Zk Notes", picker = config.options.picker, multi_select = true }, options or {})
 
+  if options.picker ~= "telescope" then
+    print(":ZkGrep is only usable with Telescope for now. Maybe time for a PR? 😘")
+    return
+  end
   if options.grep ~= nil then
     require("zk.pickers." .. options.picker).show_note_grep_picker(options, cb)
   else


### PR DESCRIPTION
Use Telescope's "jobs" to perform live asynchronous calls to `zk list -m` to provide grep-like searching of note bodies