### PR TITLE
enforce current stylua style

### DIFF
--- a/lua/zk.lua
+++ b/lua/zk.lua
@@ -98,7 +98,8 @@ end
 ---@see https://github.com/zk-org/zk/blob/main/docs/editors-integration.md#zklist
 ---@see zk.ui.pick_notes
 function M.pick_notes(options, picker_options, cb)
-  options = vim.tbl_extend("force", { select = ui.get_pick_notes_list_api_selection(picker_options) }, options or {})
+  options =
+    vim.tbl_extend("force", { select = ui.get_pick_notes_list_api_selection(picker_options) }, options or {})
   api.list(options.notebook_path, options, function(err, notes)
     assert(not err, tostring(err))
     ui.pick_notes(notes, picker_options, cb)

--- a/lua/zk/pickers/fzf_lua.lua
+++ b/lua/zk/pickers/fzf_lua.lua
@@ -10,121 +10,117 @@ local delimiter = "\x01"
 local fzf_lua_previewer = builtin_previewer.buffer_or_file:extend()
 
 function fzf_lua_previewer:new(o, opts, fzf_win)
-    fzf_lua_previewer.super.new(self, o, opts, fzf_win)
-    setmetatable(self, fzf_lua_previewer)
-    return self
+  fzf_lua_previewer.super.new(self, o, opts, fzf_win)
+  setmetatable(self, fzf_lua_previewer)
+  return self
 end
 
 function fzf_lua_previewer:parse_entry(entry)
-    local path = entry:match("([^" .. delimiter .. "]+)")
-    return { path = path, }
+  local path = entry:match("([^" .. delimiter .. "]+)")
+  return { path = path }
 end
 
 local function path_from_selected(selected)
-    return vim.tbl_map(function(line)
-        return string.match(line, "([^" .. delimiter .. "]+)")
-    end, selected)
+  return vim.tbl_map(function(line)
+    return string.match(line, "([^" .. delimiter .. "]+)")
+  end, selected)
 end
 
 M.note_picker_list_api_selection = { "title", "absPath", "path" }
 
 function M.show_note_picker(notes, options, cb)
-    options = options or {}
-    local notes_by_path = {}
-    local fzf_opts = vim.tbl_deep_extend("force", {
-        prompt = options.title .. " ❯ ",
-        previewer = fzf_lua_previewer,
-        fzf_opts = {
-            ["--delimiter"] = delimiter,
-            ["--tiebreak"] = "index",
-            ["--with-nth"] = 2,
-            ["--tabstop"] = 4,
-        },
-        -- we rely on `fzf-lua` to open notes in any other case than the default (pressing enter) 
-        -- to take advantage of the plugin builtin actions like opening in a split
-        actions = {
-            ["default"] = function(selected, opts)
-                local selected_notes = vim.tbl_map(function(line)
-                    local path = string.match(line, "([^" .. delimiter .. "]+)")
-                    return notes_by_path[path]
-                end, selected)
-                if options.multi_select then
-                    cb(selected_notes)
-                else
-                    cb(selected_notes[1])
-                end
-            end,
-            ["ctrl-s"] = function(selected, opts)
-                local entries = path_from_selected(selected)
-                actions.file_split(entries, opts)
-            end,
-            ["ctrl-v"] = function(selected, opts)
-                local entries = path_from_selected(selected)
-                actions.file_vsplit(entries, opts)
-            end,
-            ["ctrl-t"] = function(selected, opts)
-                local entries = path_from_selected(selected)
-                actions.file_tabedit(entries, opts)
-            end,
-        },
-    }, options.fzf_lua or {})
-
-    exec(function(fzf_cb)
-        for _, note in ipairs(notes) do
-            local title = note.title or note.path
-            local entry = table.concat({ note.absPath, title }, delimiter)
-            notes_by_path[note.absPath] = note
-            fzf_cb(entry)
+  options = options or {}
+  local notes_by_path = {}
+  local fzf_opts = vim.tbl_deep_extend("force", {
+    prompt = options.title .. " ❯ ",
+    previewer = fzf_lua_previewer,
+    fzf_opts = {
+      ["--delimiter"] = delimiter,
+      ["--tiebreak"] = "index",
+      ["--with-nth"] = 2,
+      ["--tabstop"] = 4,
+    },
+    -- we rely on `fzf-lua` to open notes in any other case than the default (pressing enter)
+    -- to take advantage of the plugin builtin actions like opening in a split
+    actions = {
+      ["default"] = function(selected, opts)
+        local selected_notes = vim.tbl_map(function(line)
+          local path = string.match(line, "([^" .. delimiter .. "]+)")
+          return notes_by_path[path]
+        end, selected)
+        if options.multi_select then
+          cb(selected_notes)
+        else
+          cb(selected_notes[1])
         end
-        fzf_cb() --EOF
-    end, fzf_opts)
+      end,
+      ["ctrl-s"] = function(selected, opts)
+        local entries = path_from_selected(selected)
+        actions.file_split(entries, opts)
+      end,
+      ["ctrl-v"] = function(selected, opts)
+        local entries = path_from_selected(selected)
+        actions.file_vsplit(entries, opts)
+      end,
+      ["ctrl-t"] = function(selected, opts)
+        local entries = path_from_selected(selected)
+        actions.file_tabedit(entries, opts)
+      end,
+    },
+  }, options.fzf_lua or {})
+
+  exec(function(fzf_cb)
+    for _, note in ipairs(notes) do
+      local title = note.title or note.path
+      local entry = table.concat({ note.absPath, title }, delimiter)
+      notes_by_path[note.absPath] = note
+      fzf_cb(entry)
+    end
+    fzf_cb() --EOF
+  end, fzf_opts)
 end
 
 function M.show_tag_picker(tags, options, cb)
-    options = options or {}
-    local tags_by_name = {}
-    local fzf_opts = vim.tbl_extend("force", {
-        prompt = options.title .. "> ",
-        fzf_opts = {
-            ["--delimiter"] = delimiter,
-            ["--tiebreak"] = "index",
-            ["--nth"] = 2,
-            ["--exact"] = "",
-            ["--tabstop"] = 4,
-        },
-        fn_selected = function(selected, _)
-            -- for some reason, fzf lua returns an empty string as the first selected line. this was
-            -- causing the tbl_map to generate a result zk-nvim can't resolve to open notes
-            table.remove(selected, 1)
-            local selected_tags = vim.tbl_map(function(line)
-                local name = string.match(line, "%d+%s+" .. delimiter .. "(.+)")
-                return tags_by_name[name]
-            end, selected)
-            if options.multi_select then
-                cb(selected_tags)
-            else
-                cb(selected_tags[1])
-            end
-        end
-    }, options.fzf_lua or {})
+  options = options or {}
+  local tags_by_name = {}
+  local fzf_opts = vim.tbl_extend("force", {
+    prompt = options.title .. "> ",
+    fzf_opts = {
+      ["--delimiter"] = delimiter,
+      ["--tiebreak"] = "index",
+      ["--nth"] = 2,
+      ["--exact"] = "",
+      ["--tabstop"] = 4,
+    },
+    fn_selected = function(selected, _)
+      -- for some reason, fzf lua returns an empty string as the first selected line. this was
+      -- causing the tbl_map to generate a result zk-nvim can't resolve to open notes
+      table.remove(selected, 1)
+      local selected_tags = vim.tbl_map(function(line)
+        local name = string.match(line, "%d+%s+" .. delimiter .. "(.+)")
+        return tags_by_name[name]
+      end, selected)
+      if options.multi_select then
+        cb(selected_tags)
+      else
+        cb(selected_tags[1])
+      end
+    end,
+  }, options.fzf_lua or {})
 
-    exec(function(fzf_cb)
-        for _, tag in ipairs(tags) do
-            -- formatting the note count to have some color, and adding a bit of space
-            local note_count = ansi_codes.bold(
-                ansi_codes.magenta(
-                    string.format("%-4d", tag.note_count)
-                )
-            )
-            local entry = table.concat({
-                note_count,
-                tag.name
-            }, delimiter)
-            tags_by_name[tag.name] = tag
-            fzf_cb(entry)
-        end
-        fzf_cb() --EOF
-    end, fzf_opts)
+  exec(function(fzf_cb)
+    for _, tag in ipairs(tags) do
+      -- formatting the note count to have some color, and adding a bit of space
+      local note_count = ansi_codes.bold(ansi_codes.magenta(string.format("%-4d", tag.note_count)))
+      local entry = table.concat({
+        note_count,
+        tag.name,
+      }, delimiter)
+      tags_by_name[tag.name] = tag
+      fzf_cb(entry)
+    end
+    fzf_cb() --EOF
+  end, fzf_opts)
 end
 
 return M

--- a/lua/zk/ui.lua
+++ b/lua/zk/ui.lua
@@ -8,8 +8,11 @@ local M = {}
 ---@param options? table containing {picker}, {title}, {multi_select} keys
 ---@param cb function
 function M.pick_notes(notes, options, cb)
-  options =
-    vim.tbl_extend("force", { title = "Zk Notes", picker = config.options.picker, multi_select = true }, options or {})
+  options = vim.tbl_extend(
+    "force",
+    { title = "Zk Notes", picker = config.options.picker, multi_select = true },
+    options or {}
+  )
   require("zk.pickers." .. options.picker).show_note_picker(notes, options, cb)
 end
 
@@ -19,8 +22,11 @@ end
 ---@param options? table containing {picker}, {title}, {multi_select} keys
 ---@param cb function
 function M.pick_tags(tags, options, cb)
-  options =
-    vim.tbl_extend("force", { title = "Zk Tags", picker = config.options.picker, multi_select = true }, options or {})
+  options = vim.tbl_extend(
+    "force",
+    { title = "Zk Tags", picker = config.options.picker, multi_select = true },
+    options or {}
+  )
   require("zk.pickers." .. options.picker).show_tag_picker(tags, options, cb)
 end
 

--- a/selene.toml
+++ b/selene.toml
@@ -1,1 +1,1 @@
-std="vim"
+std = "vim"

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,2 +1,5 @@
 indent_type = "Spaces"
 indent_width = 2
+column_width = 110
+quote_style = "AutoPreferDouble"
+call_parentheses = "Always"


### PR DESCRIPTION
During #171 I noticed that the call_parenthesis stylua setting had not been set in `stylua.toml`. 

Updated the stylua.toml file accordingly in keeping with the current formatting in the project and formatted the whole project.

I added a line length of 110 as a sane default (and personal preference). 
It's fairly arguable to have some hard setting for line length to catch future contributions with line wrap on?..