### PR TITLE
fix(setup): not really detecting external clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ To get the best experience, it's recommended to also install either [Telescope](
 > If you have the [zk cli](https://github.com/zk-org/zk) installed, then you do not need to install the `zk lsp` via the regular neovim paradigm (Mason, nvim-lsp, etc).
 > This is because `zk` has our lsp bundled with it, which `zk-nvim` hooks into.
 > Additionally, `zk-nvim` will setup and start the LSP server for you, do *not* call `require("lspconfig").zk.setup()`.
+> If you already had `require("lspconfig").zk.setup()` in use, please set `opt.lsp.auto_attach` to false `zk-nvim` will find the existed instance of `zk` lsp client automatically.
 
 ```lua
 require("zk").setup()

--- a/lua/zk.lua
+++ b/lua/zk.lua
@@ -21,9 +21,9 @@ end
 
 ---Automatically called via an |autocmd| if lsp.auto_attach is enabled.
 --
----@param bufnr number
+---@param bufnr integer
 function M._lsp_buf_auto_add(bufnr)
-  if vim.api.nvim_buf_get_option(bufnr, "buftype") == "nofile" then
+  if vim.bo[bufnr].buftype == "nofile" then
     return
   end
 

--- a/lua/zk/api.lua
+++ b/lua/zk/api.lua
@@ -15,7 +15,6 @@ local function execute_command(cmd, path, options, cb)
     options = nil
   end
   local bufnr = 0
-  lsp.start()
   lsp.client().request("workspace/executeCommand", {
     command = "zk." .. cmd,
     arguments = {

--- a/lua/zk/lsp.lua
+++ b/lua/zk/lsp.lua
@@ -45,8 +45,11 @@ end
 ---@param bufnr number
 function M.buf_add(bufnr)
   bufnr = bufnr or 0
-  M.start()
-  vim.lsp.buf_attach_client(bufnr, client_id)
+  --Prevent multiple client starts in the same event loop
+  vim.schedule(function()
+    M.start()
+    vim.lsp.buf_attach_client(bufnr, client_id)
+  end)
 end
 
 ---Stops the LSP client managed by this plugin

--- a/lua/zk/lsp.lua
+++ b/lua/zk/lsp.lua
@@ -18,13 +18,13 @@ function M.external_client()
     active_clients = vim.lsp.get_active_clients({ name = client_name })
   end
 
-  if vim.tbl_isempty(active_clients) then
+  if next(active_clients) == nil then
     return nil
   end
 
   -- return first lsp server that is actually in use
   for _, v in ipairs(active_clients) do
-    if not vim.tbl_isempty(v.attached_buffers) then
+    if next(v.attached_buffers) ~= nil then
       return v.id
     end
   end

--- a/lua/zk/lsp.lua
+++ b/lua/zk/lsp.lua
@@ -18,13 +18,13 @@ function M.external_client()
     active_clients = vim.lsp.get_active_clients({ name = client_name })
   end
 
-  if active_clients == {} then
+  if vim.tbl_isempty(active_clients) then
     return nil
   end
 
   -- return first lsp server that is actually in use
   for _, v in ipairs(active_clients) do
-    if v.attached_buffers ~= {} then
+    if not vim.tbl_isempty(v.attached_buffers) then
       return v.id
     end
   end


### PR DESCRIPTION
Two Problem:

 - `tbl == {}` is not the right way to tell if a table is empty in Lua, which makes the `external_client` meaningless. 

 - If two client starts in the same event loop, it will start `zk` twice. e.g. when user try to use filetype autocmd to start `zk` and `zk-nvim` together.

Two Solution:

 - Use `next(tbl)==nil` or `vim.tbl_isempty(tbl)` instead.
 
 - Use `vim.schedule` to prevent multiple client starts in the same event loop.