### PR TITLE
Fix get_text_in_range when the last character is multibyte

### DIFF
--- a/lua/zk/commands/builtin.lua
+++ b/lua/zk/commands/builtin.lua
@@ -19,7 +19,7 @@ end)
 
 commands.add("ZkNewFromTitleSelection", function(options)
   local location = util.get_lsp_location_from_selection()
-  local selected_text = util.get_text_in_range(location.range)
+  local selected_text = util.get_selected_text()
   assert(selected_text ~= nil, "No selected text")
 
   options = options or {}
@@ -38,7 +38,7 @@ end, { needs_selection = true })
 
 commands.add("ZkNewFromContentSelection", function(options)
   local location = util.get_lsp_location_from_selection()
-  local selected_text = util.get_text_in_range(location.range)
+  local selected_text = util.get_selected_text()
   assert(selected_text ~= nil, "No selected text")
 
   options = options or {}
@@ -75,7 +75,7 @@ local function insert_link(selected, opts)
   opts = vim.tbl_extend("force", {}, opts or {})
 
   local location = util.get_lsp_location_from_selection()
-  local selected_text = util.get_text_in_range(util.get_selected_range())
+  local selected_text = util.get_selected_text()
 
   if not selected then
     location = util.get_lsp_location_from_caret()
@@ -110,7 +110,7 @@ commands.add("ZkInsertLinkAtSelection", function(opts)
 end, { title = "Insert Zk link", needs_selection = true })
 
 commands.add("ZkMatch", function(options)
-  local selected_text = util.get_text_in_range(util.get_selected_range())
+  local selected_text = util.get_selected_text()
   assert(selected_text ~= nil, "No selected text")
   options = vim.tbl_extend("force", { match = { selected_text } }, options or {})
   zk.edit(options, { title = "Zk Notes matching " .. vim.inspect(selected_text) })

--- a/lua/zk/util.lua
+++ b/lua/zk/util.lua
@@ -47,7 +47,7 @@ function M.get_lsp_location_from_selection()
   local params = vim.lsp.util.make_given_range_params()
   return {
     uri = params.textDocument.uri,
-    range = M.get_selected_range(), -- workaround for neovim 0.6.1 bug (https://github.com/zk-org/zk-nvim/issues/19)
+    range = params.range
   }
 end
 
@@ -91,16 +91,11 @@ function M.get_lsp_location_from_caret()
   })
 end
 
----Gets the text in the given range of the current buffer.
----Needed until https://github.com/neovim/neovim/pull/13896 is merged.
+---Gets the text in the last visual selection
 --
----@param range table contains {start} and {end} tables with {line} (0-indexed, end inclusive) and {character} (0-indexed, end exclusive) values
----@return string? text in range
-function M.get_text_in_range(range)
-  local A = range["start"]
-  local B = range["end"]
-
-  local region = vim.region(0, { A.line, A.character }, { B.line, B.character }, vim.fn.visualmode(), true)
+---@return string text in range
+function M.get_selected_text()
+  local region = vim.region(0, "'<", "'>", vim.fn.visualmode(), true)
 
   local chunks = {}
   local maxcol = vim.v.maxcol
@@ -110,30 +105,6 @@ function M.get_text_in_range(range)
     table.insert(chunks, chunk)
   end
   return table.concat(chunks, "\n")
-end
-
----Gets the most recently selected range of the current buffer.
----That is the text between the '<,'> marks.
----Note that these marks are only updated *after* leaving the visual mode.
---
----@return table selected range, contains {start} and {end} tables with {line} (0-indexed, end inclusive) and {character} (0-indexed, end exclusive) values
-function M.get_selected_range()
-  -- code adjusted from `vim.lsp.util.make_given_range_params`
-  -- we don't want to use character encoding offsets here
-
-  local A = vim.api.nvim_buf_get_mark(0, "<")
-  local B = vim.api.nvim_buf_get_mark(0, ">")
-
-  -- convert to 0-index
-  A[1] = A[1] - 1
-  B[1] = B[1] - 1
-  if vim.o.selection ~= "exclusive" then
-    B[2] = B[2] + 1
-  end
-  return {
-    start = { line = A[1], character = A[2] },
-    ["end"] = { line = B[1], character = B[2] },
-  }
 end
 
 return M


### PR DESCRIPTION
The previous implementation would only copy the first byte of the last
character. This is never correct, and produces an invalid sequence.

See: https://github.com/zk-org/zk-nvim/issues/179