### PR TITLE
feat: ZkBuffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,13 @@ see what they can do, and learn as you go.
 ```
 
 ```vim
+" Opens a notes picker for active buffers (showing notebook files only).
+" params
+"   (optional) additional options, see https://github.com/zk-org/zk/blob/main/docs/tips/editors-integration.md#zklist
+:ZkBuffers [{options}]
+```
+
+```vim
 " Opens a notes picker for the backlinks of the current buffer
 " params
 "   (optional) additional options, see https://github.com/zk-org/zk/blob/main/docs/tips/editors-integration.md#zklist

--- a/lua/zk/commands/builtin.lua
+++ b/lua/zk/commands/builtin.lua
@@ -61,6 +61,12 @@ commands.add("ZkNotes", function(options)
   zk.edit(options, { title = "Zk Notes" })
 end)
 
+commands.add("ZkBuffers", function(options)
+  local hrefs = util.get_buffer_paths()
+  options = vim.tbl_extend("force", { hrefs = hrefs }, options or {})
+  zk.edit(options, { title = "Zk Buffers" })
+end)
+
 commands.add("ZkBacklinks", function(options)
   options = vim.tbl_extend("force", { linkTo = { vim.api.nvim_buf_get_name(0) } }, options or {})
   zk.edit(options, { title = "Zk Backlinks" })

--- a/lua/zk/util.lua
+++ b/lua/zk/util.lua
@@ -47,7 +47,7 @@ function M.get_lsp_location_from_selection()
   local params = vim.lsp.util.make_given_range_params()
   return {
     uri = params.textDocument.uri,
-    range = params.range
+    range = params.range,
   }
 end
 
@@ -91,7 +91,7 @@ function M.get_lsp_location_from_caret()
   })
 end
 
----Gets the text in the last visual selection
+---Gets the text in the last visual selection.
 --
 ---@return string text in range
 function M.get_selected_text()
@@ -105,6 +105,24 @@ function M.get_selected_text()
     table.insert(chunks, chunk)
   end
   return table.concat(chunks, "\n")
+end
+
+---Gets the file paths of active buffers.
+--
+---@return table Paths of currently active buffers.
+function M.get_buffer_paths()
+  local buffers = vim.api.nvim_list_bufs()
+  local paths = {}
+
+  for _, buf in ipairs(buffers) do
+    local path = vim.api.nvim_buf_get_name(buf)
+
+    if path ~= "" then
+      table.insert(paths, path)
+    end
+  end
+
+  return paths
 end
 
 return M


### PR DESCRIPTION
Shows all active note buffers in your picker of choice.

Run `:ZkBuffers`

The underlying call is the same as `ZkNotes` and therefore accepts the same options, as listed [here in the docs](https://github.com/zk-org/zk/blob/main/docs/tips/editors-integration.md#zklist).