### PR TITLE
feat: add builtin command `ZkNewFromTitleAndContentSelection`

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,14 @@ see what they can do, and learn as you go.
 "   (optional) additional options, see https://github.com/zk-org/zk/blob/main/docs/tips/editors-integration.md#zknew
 :'<,'>ZkNewFromContentSelection [{options}]
 
+" Creates a new note and uses the last visual selection as the title and content (delimited by newlines) while replacing the selection with a link to the new note
+"
+" Use the `inline = true` option to replace the selection with the content of the created note, instead of writing the note on the file system.
+"
+" params
+"   (optional) additional options, see https://github.com/zk-org/zk/blob/main/docs/tips/editors-integration.md#zknew
+:'<,'>ZkNewFromTitleAndContentSelection [{options}]
+
 " cd into the notebook root
 " params
 "   (optional) additional options
@@ -477,6 +485,8 @@ if require("zk.util").notebook_root(vim.fn.expand('%:p')) ~= nil then
   map("v", "<leader>znt", ":'<,'>ZkNewFromTitleSelection { dir = vim.fn.expand('%:p:h') }<CR>", opts)
   -- Create a new note in the same directory as the current buffer, using the current selection for note content and asking for its title.
   map("v", "<leader>znc", ":'<,'>ZkNewFromContentSelection { dir = vim.fn.expand('%:p:h'), title = vim.fn.input('Title: ') }<CR>", opts)
+  -- Create a new note in the same directory as the current buffer, using the current selection for note title and content (delimited by newlines).
+  map("v", "<leader>znn", ":'<,'>ZkNewFromTitleAndContentSelection { dir = vim.fn.expand('%:p:h') }<CR>", opts)
 
   -- Open notes linking to the current buffer.
   map("n", "<leader>zb", "<Cmd>ZkBacklinks<CR>", opts)

--- a/lua/zk/commands/builtin.lua
+++ b/lua/zk/commands/builtin.lua
@@ -61,7 +61,7 @@ commands.add("ZkNewFromTitleAndContentSelection", function(options)
   assert(selected_text ~= nil, "No selected text")
 
   local title, content = selected_text:match("%W*([^\n]+)\n+(.+)$")
-  assert(title ~= nil and content ~= nil, "No newline-delimited title and content found in selection")
+  assert(title ~= nil or content ~= nil, "No newline-delimited title and content found in selection")
 
   options = options or {}
   options.title = vim.fn.input("Title: ", title)

--- a/lua/zk/commands/builtin.lua
+++ b/lua/zk/commands/builtin.lua
@@ -55,6 +55,29 @@ commands.add("ZkNewFromContentSelection", function(options)
   zk.new(options)
 end, { needs_selection = true })
 
+commands.add("ZkNewFromTitleAndContentSelection", function(options)
+  local location = util.get_lsp_location_from_selection()
+  local selected_text = util.get_selected_text()
+  assert(selected_text ~= nil, "No selected text")
+
+  local title, content = selected_text:match("%W*([^\n]+)\n+([^\n]+)$")
+  assert(title ~= nil and content ~= nil, "No newline-separated title and content found in selection")
+
+  options = options or {}
+  options.title = vim.fn.input("Title: ", title)
+  options.content = content
+
+  if options.inline == true then
+    options.inline = nil
+    options.dryRun = true
+    options.insertContentAtLocation = location
+  else
+    options.insertLinkAtLocation = location
+  end
+
+  zk.new(options)
+end, { needs_selection = true })
+
 commands.add("ZkCd", zk.cd)
 
 commands.add("ZkNotes", function(options)

--- a/lua/zk/commands/builtin.lua
+++ b/lua/zk/commands/builtin.lua
@@ -60,7 +60,7 @@ commands.add("ZkNewFromTitleAndContentSelection", function(options)
   local selected_text = util.get_selected_text()
   assert(selected_text ~= nil, "No selected text")
 
-  local title, content = selected_text:match("%W*([^\n]+)\n+([^\n]+)$")
+  local title, content = selected_text:match("%W*([^\n]+)\n+(.+)$")
   assert(title ~= nil and content ~= nil, "No newline-delimited title and content found in selection")
 
   options = options or {}

--- a/lua/zk/commands/builtin.lua
+++ b/lua/zk/commands/builtin.lua
@@ -61,7 +61,7 @@ commands.add("ZkNewFromTitleAndContentSelection", function(options)
   assert(selected_text ~= nil, "No selected text")
 
   local title, content = selected_text:match("%W*([^\n]+)\n+([^\n]+)$")
-  assert(title ~= nil and content ~= nil, "No newline-separated title and content found in selection")
+  assert(title ~= nil and content ~= nil, "No newline-delimited title and content found in selection")
 
   options = options or {}
   options.title = vim.fn.input("Title: ", title)


### PR DESCRIPTION
I'm enjoying the plugin and appreciate the builtin commands `ZkNewFromContentSelection` and `ZkNewFromTitleSelection` to refactor and atomize growing notes. However the section I wish to extract frequently already has a markdown heading, e.g.

```markdown
# Cats

...

## The origin of cats

- Nearly all cats, including lions, tigers and the domestic cat, are descended from one prehistoric creature.
- The oldest known relative, the African Wildcat, first developed over 10,000 years ago.
```

So I wrote a new command that will extract the selection's first line as the title (ignoring any starting non-characters like `#` and `-`), and the rest as the content. I think it complements the aforementioned builtins nicely and imagine I'm not the only one with this workflow, hence the PR. Feel free to disagree :)