### PR TITLE
Added the ability to pass down default options to pickers

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,3 +573,24 @@ require("telescope").load_extension("zk")
 :Telescope zk tags
 :Telescope zk tags created=today
 ```
+
+## Picker Configuration
+
+You can define default configurations for the pickers opened by `zk-nvim`, allowing you to apply a specific theme or layout for `zk-nvim`. This works for all supported pickers, but you'll need to refer to the relevant configuration options for each picker.
+
+```lua
+require("zk").setup({
+    picker_options = {
+        telescope = require("telescope.themes").get_ivy(),
+
+        -- or if you use snacks picker
+
+        snacks_picker = {
+            layout = {
+                preset = "ivy",
+            }
+        },
+    },
+    ...
+})
+```

--- a/doc/zk.txt
+++ b/doc/zk.txt
@@ -19,6 +19,7 @@ CONTENTS                                                             *zk-content
     2.1. Syntax Highlighting Tips....................|zk-syntax_highlighting_tips|
     2.2. nvim-lsp-installer................................|zk-nvim-lsp-installer|
     2.3. Telescope Plugin....................................|zk-telescope_plugin|
+    2.4. Picker Configuration............................|zk-picker_configuration|
 
 ================================================================================
 ZK-NVIM                                                               *zk-zk-nvim*
@@ -493,6 +494,29 @@ It's possible (but unnecessary) to also load the notes and tags pickers as a tel
     :Telescope zk notes createdAfter=3\ days\ ago
     :Telescope zk tags
     :Telescope zk tags created=today
+<
+
+--------------------------------------------------------------------------------
+PICKER CONFIGURATION                                     *zk-picker_configuration*
+
+You can define default configurations for the pickers opened by `zk-nvim`, allowing you to apply a specific theme or layout to `zk-nvim`. This works for all supported pickers, but you'll need to refer to the relevant configuration options for each picker.
+
+Example configuration:
+>
+  require("zk").setup({
+      picker_options = {
+          telescope = require("telescope.themes").get_ivy(),
+
+          -- or if you use snacks picker
+
+          snacks_picker = {
+              layout = {
+                  preset = "ivy",
+              }
+          },
+      },
+      ...
+  })
 <
 
 ==============================================================================

--- a/lua/zk/ui.lua
+++ b/lua/zk/ui.lua
@@ -11,6 +11,7 @@ function M.pick_notes(notes, options, cb)
   options = vim.tbl_extend(
     "force",
     { title = "Zk Notes", picker = config.options.picker, multi_select = true },
+    config.options.picker_options or {},
     options or {}
   )
   require("zk.pickers." .. options.picker).show_note_picker(notes, options, cb)
@@ -25,6 +26,7 @@ function M.pick_tags(tags, options, cb)
   options = vim.tbl_extend(
     "force",
     { title = "Zk Tags", picker = config.options.picker, multi_select = true },
+    config.options.picker_options or {},
     options or {}
   )
   require("zk.pickers." .. options.picker).show_tag_picker(tags, options, cb)
@@ -35,7 +37,12 @@ end
 ---@param options table the same options that are use for pick_notes
 ---@return table api selection
 function M.get_pick_notes_list_api_selection(options)
-  options = vim.tbl_extend("force", { picker = config.options.picker }, options or {})
+  options = vim.tbl_extend(
+    "force",
+    { picker = config.options.picker },
+    config.options.picker_options or {},
+    options or {}
+  )
   return require("zk.pickers." .. options.picker).note_picker_list_api_selection
 end
 


### PR DESCRIPTION
**Title:** 
Add support to set default configurations for pickers

**Description:**
Hi there, I've been using the plugin recently, and it's been great! However, I prefer using the Ivy format with Telescope. To allow users more flexibility in customizing their picker, I’ve added support for passing down picker options from the configuration.

This was made in consideration of the other pickers too, users can define default configurations for `fzf_options`, `snacks_picker` and ect.

Here is an example of how this would be used:
```lua
require("zk").setup({
  picker = "telescope",

  picker_options = {
    telescope = {
      layout_strategy = "bottom_pane",
      sorting_strategy = "ascending",
      layout_config = {
        height = 25,
      },
      border = true,
      borderchars = {
        prompt = { "─", " ", " ", " ", "─", "─", " ", " " },
        results = { " " },
        preview = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" },
      },
    },
  },
...
})

```