### PR TITLE
feat: create new note from fzf_lua notes picker

### DIFF
--- a/lua/zk/pickers/fzf_lua.lua
+++ b/lua/zk/pickers/fzf_lua.lua
@@ -39,6 +39,7 @@ function M.show_note_picker(notes, options, cb)
       ["--tiebreak"] = "index",
       ["--with-nth"] = 2,
       ["--tabstop"] = 4,
+      ["--header"] = ansi_codes.blue("CTRL-E: create a note with the query as title"),
     },
     -- we rely on `fzf-lua` to open notes in any other case than the default (pressing enter)
     -- to take advantage of the plugin builtin actions like opening in a split
@@ -65,6 +66,10 @@ function M.show_note_picker(notes, options, cb)
       ["ctrl-t"] = function(selected, opts)
         local entries = path_from_selected(selected)
         actions.file_tabedit(entries, opts)
+      end,
+      ["ctrl-e"] = function()
+        local query = require("fzf-lua").config.__resume_data.last_query
+        require("zk").new({ title = query })
       end,
     },
   }, options.fzf_lua or {})


### PR DESCRIPTION
## Description

This makes it possible to create a new note from the note pickers. Currently only implemented for fzf_lua because that is what I use.

![CleanShot 2025-04-20 at 19 05 54@2x](https://github.com/user-attachments/assets/e6d49090-0a07-428b-8a2c-ff63c2f6a5e7)

If this patch doesn't get merged, here is an example to get this behavior from your own config.

```lua
  local zk = require("zk")
  local ansi_codes = require("fzf-lua").utils.ansi_codes

  local opts = function(tbl)
    return vim.tbl_extend("keep", { buffer = 0, silent = true }, tbl)
  end

  vim.keymap.set("n", "<space>zf", function()
    zk.edit({ sort = { "modified" } }, {
      fzf_lua = {
        fzf_opts = {
          ["--header"] = ansi_codes.blue("CTRL-E: create a note with the query as title"),
        },
        actions = {
          ["ctrl-e"] = function()
            local query = require("fzf-lua").config.__resume_data.last_query
            require("zk").new { title = query }
          end,
        },
      },
    })
  end, opts { desc = "Find notes" })
```

Related to #200 