### PR TITLE
Fix position encoding parameter warning when creating note from selection

### DIFF
--- a/lua/zk/util.lua
+++ b/lua/zk/util.lua
@@ -53,6 +53,7 @@ local function get_offset_encoding(bufnr)
       string.format("ZK Client (id: %s) offset_encoding is nil. Do not unset offset_encoding.", zk_client.id),
       error_level
     )
+  else
     offset_encoding = zk_client.offset_encoding
   end
   return offset_encoding

--- a/lua/zk/util.lua
+++ b/lua/zk/util.lua
@@ -62,7 +62,6 @@ end
 local function make_range_zk()
   local bufnr = vim.api.nvim_get_current_buf()
   local offset_encoding = get_offset_encoding(bufnr)
-  vim.notify(offset_encoding)
   -- This function has a warning if encoding is not passed
   return vim.lsp.util.make_given_range_params(nil, nil, bufnr, offset_encoding)
 end

--- a/lua/zk/util.lua
+++ b/lua/zk/util.lua
@@ -59,15 +59,20 @@ local function get_offset_encoding(bufnr)
   return offset_encoding
 end
 
+local function make_range_zk()
+  local bufnr = vim.api.nvim_get_current_buf()
+  local offset_encoding = get_offset_encoding(bufnr)
+  vim.notify(offset_encoding)
+  -- This function has a warning if encoding is not passed
+  return vim.lsp.util.make_given_range_params(nil, nil, bufnr, offset_encoding)
+end
+
 ---Makes an LSP location object from the last selection in the current buffer.
 --
 ---@return table LSP location object
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#location
 function M.get_lsp_location_from_selection()
-  local bufnr = vim.api.nvim_get_current_buf()
-  local offset_encoding = get_offset_encoding(bufnr)
-  -- This function has a warning if encoding is not passed
-  local params = vim.lsp.util.make_given_range_params(nil, nil, bufnr, offset_encoding)
+  local params = make_range_zk()
   return {
     uri = params.textDocument.uri,
     range = params.range,
@@ -101,7 +106,7 @@ end
 ---@return table LSP location object
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#location
 function M.get_lsp_location_from_caret()
-  local params = vim.lsp.util.make_given_range_params()
+  local params = make_range_zk()
 
   local row, col = unpack(vim.api.nvim_win_get_cursor(0))
   local position = { line = row, character = col }

--- a/lua/zk/util.lua
+++ b/lua/zk/util.lua
@@ -39,12 +39,34 @@ function M.resolve_notebook_path(bufnr)
   return path
 end
 
+local function get_offset_encoding(bufnr)
+  -- Modified from nvim's vim.lsp.util._get_offset_encoding()
+  vim.validate("bufnr", bufnr, "number", true)
+  local zk_client = vim.lsp.get_clients({ bufnr = bufnr, name = "zk" })[1]
+  local error_level = vim.log.levels.ERROR
+  local offset_encoding --- @type 'utf-8'|'utf-16'|'utf-32'
+  if zk_client == nil then
+    vim.notify_once("No zk client found for this buffer. Using default encoding of utf-16", error_level)
+    offset_encoding = "utf-16"
+  elseif zk_client.offset_encoding == nil then
+    vim.notify_once(
+      string.format("ZK Client (id: %s) offset_encoding is nil. Do not unset offset_encoding.", zk_client.id),
+      error_level
+    )
+    offset_encoding = zk_client.offset_encoding
+  end
+  return offset_encoding
+end
+
 ---Makes an LSP location object from the last selection in the current buffer.
 --
 ---@return table LSP location object
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#location
 function M.get_lsp_location_from_selection()
-  local params = vim.lsp.util.make_given_range_params()
+  local bufnr = vim.api.nvim_get_current_buf()
+  local offset_encoding = get_offset_encoding(bufnr)
+  -- This function has a warning if encoding is not passed
+  local params = vim.lsp.util.make_given_range_params(nil, nil, bufnr, offset_encoding)
   return {
     uri = params.textDocument.uri,
     range = params.range,


### PR DESCRIPTION
When creating a note from title selection with `ZkNewFromTitleSelection`, I keep getting this warning:

```lua
position_encoding param is required in vim.lsp.util.make_given_range_params. Defaulting to position encoding of the first client.
```

It can be fixed by passing the encoding explicitly. For zk, this seems to be utf-16 (`:lua= vim.lsp.get_clients({ name = "zk" })[1].offset_encoding`).

This PR fixes the issue by 1) finding the zk client and 2) setting the encoding to what the zk client returns, or to utf-16 if no zk client is found (but with an error message in the latter case).

I'm not sure if the whole encoding detection part is necessary. Could we just hardcode "utf-16" as an argument to `make_given_range_params` directly or could this change depending on ZK installations?

Thanks!