### PR TITLE
update deprecated api methods and remove nvim-0.10 version check

### DIFF
--- a/lua/zk/lsp.lua
+++ b/lua/zk/lsp.lua
@@ -12,11 +12,7 @@ function M.external_client()
   end
 
   local active_clients = {}
-  if vim.fn.has("nvim-0.10") == 1 then
-    active_clients = vim.lsp.get_clients({ name = client_name })
-  else
-    active_clients = vim.lsp.get_active_clients({ name = client_name })
-  end
+  active_clients = vim.lsp.get_clients({ name = client_name })
 
   if next(active_clients) == nil then
     return
@@ -37,7 +33,7 @@ function M.start()
   end
 
   if not client_id then
-    client_id = vim.lsp.start_client(config.options.lsp.config)
+    client_id = vim.lsp.start(config.options.lsp.config)
   end
 end
 

--- a/lua/zk/root_pattern_util.lua
+++ b/lua/zk/root_pattern_util.lua
@@ -10,11 +10,7 @@ local M = {}
 -- Some path utilities
 
 local function tbl_flatten(...)
-  if vim.fn.has("nvim-0.10") == 1 then
-    return vim.iter({ ... }):flatten():totable()
-  else
-    return vim.tbl_flatten({ ... })
-  end
+  return vim.iter({ ... }):flatten():totable()
 end
 
 M.path = (function()


### PR DESCRIPTION
Resolves #219 

Checks for nvim v0.10.* are also removed. This pr will therefore mark the point where neovim version 10.* stops to be supported with latest versions of zk-nvim.