### PR TITLE
add some guards to lsp client_id use

### DIFF
--- a/lua/zk/lsp.lua
+++ b/lua/zk/lsp.lua
@@ -42,7 +42,9 @@ end
 function M.buf_add(bufnr)
   bufnr = bufnr or 0
   M.start()
-  vim.lsp.buf_attach_client(bufnr, client_id)
+  if client_id then
+    vim.lsp.buf_attach_client(bufnr, client_id)
+  end
 end
 
 ---Stops the LSP client managed by this plugin
@@ -56,7 +58,9 @@ end
 
 ---Gets the LSP client managed by this plugin, might be nil
 function M.client()
-  return vim.lsp.get_client_by_id(client_id)
+  if client_id then
+    return vim.lsp.get_client_by_id(client_id)
+  end
 end
 
 return M


### PR DESCRIPTION
when i ran `zk new` from the cli, I would get this error in nvim, it seems to connect to the lsp and work eventually, but maybe this is an ordering thing? (I'm out of my element here, but maybe the lsp takes some time to boot up or such?). 

It's probably nice to have these guards in place regardless? They show up as warnings with lua diagnostics 🤔. 