### PR TITLE
fix client_id expected number got nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,6 @@ to see it in action.
 
 ## Requirements
 
-> [!WARNING]
-> `zk-nvim` is currently broken with `zk-nvim` 0.4.0 and `nvim` 0.11.0.
-> It's recommended to stay on neovim 0.10.4 for now.
-> [See here](https://github.com/zk-org/zk-nvim/pull/230)
-
 | `zk-nvim`     | `zk`            | Neovim         |
 | ------------- | --------------- | -------------- |
 | 0.4.0 - HEAD  | >=0.15.1        | >= 0.11.0      |

--- a/lua/zk.lua
+++ b/lua/zk.lua
@@ -6,33 +6,6 @@ local util = require("zk.util")
 
 local M = {}
 
-local function setup_lsp_auto_attach()
-  --- NOTE: modified version of code in nvim-lspconfig
-  local trigger
-  local filetypes = config.options.lsp.auto_attach.filetypes
-  if filetypes then
-    trigger = "FileType " .. table.concat(filetypes, ",")
-  else
-    trigger = "BufReadPost *"
-  end
-  M._lsp_buf_auto_add(0)
-  vim.api.nvim_command(string.format("autocmd %s lua require'zk'._lsp_buf_auto_add(0)", trigger))
-end
-
----Automatically called via an |autocmd| if lsp.auto_attach is enabled.
---
----@param bufnr number
-function M._lsp_buf_auto_add(bufnr)
-  if vim.api.nvim_buf_get_option(bufnr, "buftype") == "nofile" then
-    return
-  end
-
-  if not util.notebook_root(vim.api.nvim_buf_get_name(bufnr)) then
-    return
-  end
-
-  lsp.buf_add(bufnr)
-end
 
 ---The entry point of the plugin
 --
@@ -40,11 +13,9 @@ end
 function M.setup(options)
   config.options = vim.tbl_deep_extend("force", config.defaults, options or {})
 
+  vim.lsp.config(config.options.lsp.config.name, config.options.lsp.config)
   if config.options.lsp.auto_attach.enabled then
-    -- setup_lsp_auto_attach()
-    -- FIX: This is a hot fix for #230. If this is the solution, then the
-    -- chain of custom functions from setup_lsp_auto_attach() should be removed
-    vim.lsp.enable("zk")
+    vim.lsp.enable(config.options.lsp.config.name)
   end
 
   require("zk.commands.builtin")

--- a/lua/zk.lua
+++ b/lua/zk.lua
@@ -41,7 +41,10 @@ function M.setup(options)
   config.options = vim.tbl_deep_extend("force", config.defaults, options or {})
 
   if config.options.lsp.auto_attach.enabled then
-    setup_lsp_auto_attach()
+    -- setup_lsp_auto_attach()
+    -- FIX: This is a hot fix for #230. If this is the solution, then the
+    -- chain of custom functions from setup_lsp_auto_attach() should be removed
+    vim.lsp.enable("zk")
   end
 
   require("zk.commands.builtin")

--- a/lua/zk/config.lua
+++ b/lua/zk/config.lua
@@ -6,10 +6,11 @@ M.defaults = {
     config = {
       cmd = { "zk", "lsp" },
       name = "zk",
+      filetypes = { "markdown" },
+      root_markers = { ".zk" },
     },
     auto_attach = {
-      enabled = true,
-      filetypes = { "markdown" },
+      enabled = true, -- calls vim.lsp.enable()
     },
   },
 }

--- a/lua/zk/lsp.lua
+++ b/lua/zk/lsp.lua
@@ -1,4 +1,5 @@
 local config = require("zk.config")
+local util = require("zk.util")
 
 local client_id = nil
 

--- a/lua/zk/lsp.lua
+++ b/lua/zk/lsp.lua
@@ -48,7 +48,6 @@ end
 
 ---Gets the LSP client managed by this plugin, might be nil
 function M.client()
-  client_id = M.external_client()
   if client_id then
     return vim.lsp.get_client_by_id(client_id)
   else

--- a/lua/zk/lsp.lua
+++ b/lua/zk/lsp.lua
@@ -56,7 +56,12 @@ end
 
 ---Gets the LSP client managed by this plugin, might be nil
 function M.client()
-  return vim.lsp.get_client_by_id(client_id)
+  if client_id then
+    return vim.lsp.get_client_by_id(client_id)
+  else
+    print("Error: No client attached.")
+    return
+  end
 end
 
 return M

--- a/lua/zk/lsp.lua
+++ b/lua/zk/lsp.lua
@@ -1,5 +1,4 @@
 local config = require("zk.config")
-local util = require("zk.util")
 
 local client_id = nil
 
@@ -38,14 +37,6 @@ function M.start()
   end
 end
 
----Starts an LSP client if necessary, and attaches the given buffer.
----@param bufnr number
-function M.buf_add(bufnr)
-  bufnr = bufnr or 0
-  M.start()
-  vim.lsp.buf_attach_client(bufnr, client_id)
-end
-
 ---Stops the LSP client managed by this plugin
 function M.stop()
   local client = M.client()
@@ -57,6 +48,7 @@ end
 
 ---Gets the LSP client managed by this plugin, might be nil
 function M.client()
+  client_id = M.external_client()
   if client_id then
     return vim.lsp.get_client_by_id(client_id)
   else

--- a/lua/zk/root_pattern_util.lua
+++ b/lua/zk/root_pattern_util.lua
@@ -8,8 +8,8 @@ local M = {}
 
 -- Some path utilities
 
-local function tbl_flatten(...)
-  return vim.iter({ ... }):flatten():totable()
+local function tbl_flatten(t)
+  return vim.iter(t):flatten()
 end
 
 M.path = (function()

--- a/lua/zk/root_pattern_util.lua
+++ b/lua/zk/root_pattern_util.lua
@@ -9,7 +9,7 @@ local M = {}
 -- Some path utilities
 
 local function tbl_flatten(t)
-  return vim.iter(t):flatten()
+  return vim.iter(t):flatten():totable()
 end
 
 M.path = (function()

--- a/lua/zk/util.lua
+++ b/lua/zk/util.lua
@@ -5,7 +5,9 @@ local M = {}
 ---@param notebook_path string
 ---@return string? root
 function M.notebook_root(notebook_path)
-  return require("zk.root_pattern_util").root_pattern(".zk")(notebook_path)
+  local root_pattern = require("zk.root_pattern_util").root_pattern(".zk")
+  local rp = root_pattern(notebook_path)
+  return rp
 end
 
 ---Try to resolve a notebook path by checking the following locations in that order


### PR DESCRIPTION
Resolves #228 

Other pr's addressing this issue: #223 #229 

(If this works) then the issue was mainly to do with a buggy change over from `vim.tbl_flatten` to [`iter:flatten`](https://neovim.io/doc/user/lua.html#Iter%3Aflatten())

This was killing the root_pattern_util functionality, and therefore not returning a notebook root, that the lsp could hook into -- which meant no client_id was being returned in any case as `zk` always wants (and needs) to find a notebook root.

> [!note]
> This is only compatible with neovim 0.11.*

This branch can be tested live by:

```lua
return {
  'zk-org/zk-nvim',
  branch = 'fix/client-nil-error',

  config = function()
    require('zk').setup()
  end,
}
```

Currently, something is stopping the lsp attaching, [see comment](https://github.com/zk-org/zk-nvim/pull/230#issuecomment-2888240051).