### PR TITLE
restore custom on_attach funcitonality in addtion to vim.lsp.enable

### DIFF
--- a/lua/zk.lua
+++ b/lua/zk.lua
@@ -6,6 +6,20 @@ local util = require("zk.util")
 
 local M = {}
 
+---Automatically called via an |autocmd| if lsp.auto_attach is enabled.
+--
+---@param bufnr number
+function M._lsp_buf_auto_add(bufnr)
+  if vim.api.nvim_buf_get_option(bufnr, "buftype") == "nofile" then
+    return
+  end
+
+  if not util.notebook_root(vim.api.nvim_buf_get_name(bufnr)) then
+    return
+  end
+
+  lsp.buf_add(bufnr)
+end
 
 ---The entry point of the plugin
 --
@@ -16,6 +30,7 @@ function M.setup(options)
   vim.lsp.config(config.options.lsp.config.name, config.options.lsp.config)
   if config.options.lsp.auto_attach.enabled then
     vim.lsp.enable(config.options.lsp.config.name)
+    M._lsp_buf_auto_add(0)
   end
 
   require("zk.commands.builtin")

--- a/lua/zk/config.lua
+++ b/lua/zk/config.lua
@@ -1,3 +1,4 @@
+local util = require("zk.util")
 local M = {}
 
 M.defaults = {

--- a/lua/zk/lsp.lua
+++ b/lua/zk/lsp.lua
@@ -1,4 +1,5 @@
 local config = require("zk.config")
+local util = require("zk.util")
 
 local client_id = nil
 
@@ -35,6 +36,14 @@ function M.start()
   if not client_id then
     client_id = vim.lsp.start(config.options.lsp.config)
   end
+end
+
+---Starts an LSP client if necessary, and attaches the given buffer.
+---@param bufnr number
+function M.buf_add(bufnr)
+  bufnr = bufnr or 0
+  M.start()
+  vim.lsp.buf_attach_client(bufnr, client_id)
 end
 
 ---Stops the LSP client managed by this plugin


### PR DESCRIPTION
Resolves #234 

I removed code in #230 that was seemingly redundant as of neovim 0.11 (vim.lsp.enable).

vim.lsp.enable takes care of auto attaching to buffers, based on filetypes.

But for whatever reason it doesn't want to do this when opening a file with a new editor instance, i.e, `zk edit -i`.

Additionally, resolving the root dir is also not working by the lsp started from a fresh instance. 
Simply executing `:e` on the same file after it's opened, you will then find two instances of the zk lsp; one with a root directory, and one without.

This is because `vim.lsp` will only reuse the client if name _and_ root_dir match. [See the documentation for `reuse_client`](https://neovim.io/doc/user/lsp.html#lsp-core)