### PR TITLE
Revert "restore custom on_attach funcitonality in addtion to vim.lsp.enable"

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,8 @@ return {
       lsp = {
         -- `config` is passed to `vim.lsp.start(config)`
         config = {
-          name = "zk",
           cmd = { "zk", "lsp" },
-          filetypes = { "markdown" },
+          name = "zk",
           -- on_attach = ...
           -- etc, see `:h vim.lsp.start()`
         },
@@ -80,6 +79,7 @@ return {
         -- automatically attach buffers in a zk notebook that match the given filetypes
         auto_attach = {
           enabled = true,
+          filetypes = { "markdown" },
         },
       },
     })

--- a/lua/zk.lua
+++ b/lua/zk.lua
@@ -6,20 +6,6 @@ local util = require("zk.util")
 
 local M = {}
 
----Automatically called via an |autocmd| if lsp.auto_attach is enabled.
---
----@param bufnr number
-function M._lsp_buf_auto_add(bufnr)
-  if vim.api.nvim_buf_get_option(bufnr, "buftype") == "nofile" then
-    return
-  end
-
-  if not util.notebook_root(vim.api.nvim_buf_get_name(bufnr)) then
-    return
-  end
-
-  lsp.buf_add(bufnr)
-end
 
 ---The entry point of the plugin
 --
@@ -30,7 +16,6 @@ function M.setup(options)
   vim.lsp.config(config.options.lsp.config.name, config.options.lsp.config)
   if config.options.lsp.auto_attach.enabled then
     vim.lsp.enable(config.options.lsp.config.name)
-    M._lsp_buf_auto_add(0)
   end
 
   require("zk.commands.builtin")

--- a/lua/zk/config.lua
+++ b/lua/zk/config.lua
@@ -1,4 +1,3 @@
-local util = require("zk.util")
 local M = {}
 
 M.defaults = {

--- a/lua/zk/lsp.lua
+++ b/lua/zk/lsp.lua
@@ -1,5 +1,4 @@
 local config = require("zk.config")
-local util = require("zk.util")
 
 local client_id = nil
 
@@ -36,14 +35,6 @@ function M.start()
   if not client_id then
     client_id = vim.lsp.start(config.options.lsp.config)
   end
-end
-
----Starts an LSP client if necessary, and attaches the given buffer.
----@param bufnr number
-function M.buf_add(bufnr)
-  bufnr = bufnr or 0
-  M.start()
-  vim.lsp.buf_attach_client(bufnr, client_id)
 end
 
 ---Stops the LSP client managed by this plugin


### PR DESCRIPTION
Reverts zk-org/zk-nvim#235

I was working on a different machine and have since tested on my main machine and a minimal config. #235 regressed all the issues that #230 fixed...

No idea how or why everything was behaving differently. Those machines are running (theoretically) identical configs and setups.

Sorry...