### PR TITLE
feat: Support custom buffer names from YAML

### DIFF
--- a/lua/zk/util.lua
+++ b/lua/zk/util.lua
@@ -154,11 +154,11 @@ function M.get_buffer_paths()
   return paths
 end
 
----Fetch yaml matter from lines
+---Parse yaml frontmatter from lines
 --
 ---@return table|nil yaml as table
 ---@return string|nil err error message
-function M.fetch_yaml(lines)
+function M.parse_yaml(lines)
   local lyaml = require("lyaml")
 
   local text = table.concat(lines, "\n")
@@ -178,6 +178,16 @@ function M.fetch_yaml(lines)
   end
 
   return yaml
+end
+
+---Load yaml frontmatter from path
+--
+---@return table|nil yaml as table
+---@return string|nil err error message
+function M.load_yaml(path)
+  local lines = vim.fn.readfile(path)
+  local yaml, err = M.parse_yaml(lines)
+  return yaml, err
 end
 
 ---Check if all the values are contained in the table


### PR DESCRIPTION
Features
- Support reading YAML frontmatter for dynamic buffer naming
- Displayed names are customizable via bufferline and neo-tree options with YAML frontmatter

Details
- Added sample integration codes  for bufferline and neo-tree
- Added `fetch_yaml()` `load_yaml()` utility function to extract YAML metadata
- Added ~~`table_has_value()`~~ `table_contains()`utility function
- Updated `README.md` to reflect the new feature
- Requires `lyaml` to be installed to fetch YAML frontmatter
- ~~Added `get_options()`~~ (Removed now)

Questions
- Is it acceptable to depend on an external library like `lyaml`?
- I've decided to use purely configured in `bufferline` and `neo-tree` options (not in zk-nvim's options)

Please let me know if there are any issues.  
No rush at all — anytime after July when it's convenient for you is totally fine.
