### PR TITLE
feat: create new note from telescope picker

### DIFF
--- a/lua/zk/pickers/telescope.lua
+++ b/lua/zk/pickers/telescope.lua
@@ -59,7 +59,11 @@ end
 
 function M.show_note_picker(notes, options, cb)
   options = options or {}
-  local telescope_options = vim.tbl_extend("force", { prompt_title = options.title }, options.telescope or {})
+  local telescope_options = vim.tbl_extend(
+    "force",
+    { prompt_title = options.title },
+    options.telescope or { prompt_title = "CTRL-E: create a note with the query as title" }
+  )
 
   pickers
     .new(telescope_options, {
@@ -69,7 +73,7 @@ function M.show_note_picker(notes, options, cb)
       }),
       sorter = conf.file_sorter(options),
       previewer = M.make_note_previewer(),
-      attach_mappings = function(prompt_bufnr)
+      attach_mappings = function(prompt_bufnr, mapping)
         actions.select_default:replace(function()
           if options.multi_select then
             local selection = {}
@@ -84,6 +88,24 @@ function M.show_note_picker(notes, options, cb)
           else
             actions.close(prompt_bufnr)
             cb(action_state.get_selected_entry().value)
+          end
+        end)
+        mapping("i", "<C-e>", function()
+          local current_picker = action_state.get_current_picker(prompt_bufnr)
+          local prompt = current_picker:_get_prompt()
+          actions.close(prompt_bufnr)
+          vim.schedule(function()
+            require("zk").new({ title = prompt })
+          end)
+        end)
+        mapping("i", "<CR>", function()
+          local entry = action_state.get_selected_entry()
+          if entry == nil then
+            actions.close(prompt_bufnr)
+          else
+            vim.schedule(function()
+              actions.select_default(prompt_bufnr)
+            end)
           end
         end)
         return true


### PR DESCRIPTION
This achieves the same functionality as #220, but now with telescope.
<img width="769" height="176" alt="image" src="https://github.com/user-attachments/assets/1eda1662-9410-463b-aee3-ec3bd4d26307" />

As mentioned in #220 this allows for the same functionality from a config:
```lua
local zk = require("zk")
local actions = require("telescope.actions")
local action_state = require("telescope.actions.state")

local opts = function(tbl)
  return vim.tbl_extend("keep", { buffer = 0, silent = true }, tbl)
end

vim.keymap.set("n", "<space>zf", function()
  zk.edit({ sort = { "modified" } }, {
    telescope = {
      prompt_title = "CTRL-E: create a note with the query as title",
      results_title = "Create new file or edit existing",
      attach_mappings = function(prompt_bufnr, mapping)
        mapping("i", "<C-e>", function()
          local current_picker = action_state.get_current_picker(prompt_bufnr)
          local prompt = current_picker:_get_prompt()
          actions.close(prompt_bufnr)
          vim.schedule(function()
            require("zk").new({ title = prompt })
          end)
        end)
        mapping("i", "<CR>", function()
          local entry = action_state.get_selected_entry()
          if entry == nil then
            actions.close(prompt_bufnr)
          else
            vim.schedule(function()
              actions.select_default(prompt_bufnr)
            end)
          end
        end)
        return true
      end,
    },
  })
end, opts({ desc = "Find notes" }))
```