### PR TITLE
fix lsp-attach / double lsp client issue

### DIFF
--- a/lua/zk/config.lua
+++ b/lua/zk/config.lua
@@ -8,6 +8,7 @@ M.defaults = {
       name = "zk",
       filetypes = { "markdown" },
       root_markers = { ".zk" },
+      root_dir = vim.fs.root(0, {'.zk'})
     },
     auto_attach = {
       enabled = true, -- calls vim.lsp.enable()


### PR DESCRIPTION
Resolves #248 and #242 

zk-nvim version v0.4.1 attempted to handle changes to the neovim lsp API. These changes to zk-nvim introduced a bug where two zk lsp clients could appear if:

- the user opens neovim fresh, and then uses `:Zk..` commands to edit/create a note.

This PR fixes this. It would seem the issue was that the `root_marker` in `vim.lsp.config` is not used by neovim lsp to determine whether an existing lsp should be reattached to the new buffer or not:

```
start({config}, {opts})                                      *vim.lsp.start()*
    Create a new LSP client and start a language server or reuses an already
    running client if one is found matching `name` and `root_dir`. Attaches
    the current buffer to the client.

    Example: >lua
        vim.lsp.start({
           name = 'my-server-name',
           cmd = {'name-of-language-server-executable'},
           root_dir = vim.fs.root(0, {'pyproject.toml', 'setup.py'}),
        })
```

So this PR simply adds the `root_dir` to our lsp config. I've left the `root_markers` attribute regardless, as maybe lsp reverses its preference somewhere else.