### PR TITLE
Revert "fix lsp-attach / double lsp client issue"

### DIFF
--- a/lua/zk/config.lua
+++ b/lua/zk/config.lua
@@ -8,7 +8,6 @@ M.defaults = {
       name = "zk",
       filetypes = { "markdown" },
       root_markers = { ".zk" },
-      root_dir = vim.fs.root(0, {'.zk'})
     },
     auto_attach = {
       enabled = true, -- calls vim.lsp.enable()


### PR DESCRIPTION
Reverts zk-org/zk-nvim#251

`root_dir` does not allow for executing `:Zk` commands when outside a notebook root...