### PR TITLE
Pass ZkTags options on to zk.edit

### DIFF
--- a/lua/zk/commands/builtin.lua
+++ b/lua/zk/commands/builtin.lua
@@ -127,6 +127,7 @@ commands.add("ZkTags", function(options)
     tags = vim.tbl_map(function(v)
       return v.name
     end, tags)
-    zk.edit({ tags = tags }, { title = "Zk Notes for tag(s) " .. vim.inspect(tags) })
+    options = vim.tbl_extend("keep", { tags = tags }, options or {})
+    zk.edit(options, { title = "Zk Notes for tag(s) " .. vim.inspect(tags) })
   end)
 end)


### PR DESCRIPTION
Pass `options` from `:ZkTags` on to `zk.edit()`, preserving `tags` selected by the user. This allows `zk.edit()` to maintain the `notebook_path` used in looking up tags.

Please let me know if there are options that should be filtered out.