### PR TITLE
feat: custom note picker output

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,33 @@ commands.add("ZkOrphans", make_edit_fn({ orphan = true }, { title = "Zk Orphans"
 commands.add("ZkRecents", make_edit_fn({ createdAfter = "2 weeks ago" }, { title = "Zk Recents" }))
 ```
 
+## Custom Picker Output
+
+view all fields for selection: https://github.com/zk-org/zk/blob/main/docs/tips/editors-integration.md#zklist
+
+### Telescope picker
+
+```lua
+zk.setup({
+	picker = "telescope",
+	picker_options = {
+        -- will appended to defaults:  { "title","path", "abspath" }
+		select = { "lead" },
+		display = {
+			separator = " -- ",
+			-- entry format: { field, width, highlight }
+			entry = {
+				{ "title", "auto" },
+				{ "lead", "remaining", "Comment" },
+			},
+            -- fields to search
+			ordinal = { "title", "lead" },
+		},
+	},
+    -- ...
+})
+```
+
 ## High-level API
 
 The high-level API is inspired by the commands provided by the `zk` CLI tool;

--- a/lua/zk/ui.lua
+++ b/lua/zk/ui.lua
@@ -43,7 +43,9 @@ function M.get_pick_notes_list_api_selection(options)
     config.options.picker_options or {},
     options or {}
   )
-  return require("zk.pickers." .. options.picker).note_picker_list_api_selection
+  local default_select = require("zk.pickers." .. options.picker).note_picker_list_api_selection
+  local extra_select = options.select
+  return vim.list_extend(default_select, extra_select)
 end
 
 return M


### PR DESCRIPTION
Default, zk note picker show only title, but i want show in format "{titile} -- {lead}"

Why?

**Before**: 
```md
# Wayland - New display server manager for Ubuntu
```

**After**
```md
# Wayland

New display server manager for Ubuntu
```


<img width="869" height="347" alt="Screenshot from 2025-09-27 15-55-26" src="https://github.com/user-attachments/assets/f833e205-4d4d-4641-83d0-afca39b97064" />


this my my zk-nvim setup for custom

```lua
		zk.setup({
			picker = "telescope",
			picker_options = {
				select = { "lead" }, -- will appended to defualt  { "title","path", "abspath" }
				display = {
					separator = " -- ",
					-- entry format: { field, width, highlight }
					entry = {
						{ "title", "auto" },
						{ "lead", "remaining", "Comment" },
					},
					ordinal = { "title", "lead" }, -- fields to search
				},
			},
	              -- ...
		})

```
