### PR TITLE
fzf_lua: fix multi_select, requires passing --multi

### DIFF
--- a/lua/zk/pickers/fzf_lua.lua
+++ b/lua/zk/pickers/fzf_lua.lua
@@ -96,6 +96,7 @@ function M.show_tag_picker(tags, options, cb)
       ["--nth"] = 2,
       ["--exact"] = "",
       ["--tabstop"] = 4,
+      ["--multi"] = options.multi_select,
     },
     actions = {
       ["default"] = function(selected, _)


### PR DESCRIPTION
Without passing `--multi`, zk's `multi_select` option does not work in conjunction with the `fzf_lua` picker.