### PR TITLE
Set title in create_note_entry_maker for Telescope quickfix

### DIFF
--- a/lua/zk/pickers/telescope.lua
+++ b/lua/zk/pickers/telescope.lua
@@ -19,6 +19,7 @@ function M.create_note_entry_maker(_)
       path = note.absPath,
       display = title,
       ordinal = title,
+      text = title,
     }
   end
 end


### PR DESCRIPTION
Fixing #266 so note titles will show in a note quickfix list created from Telescope.