### PR TITLE
fix broken ZkInsertLink

### DIFF
--- a/lua/zk/commands/builtin.lua
+++ b/lua/zk/commands/builtin.lua
@@ -81,11 +81,12 @@ local function insert_link(selected, opts)
   opts = vim.tbl_extend("force", {}, opts or {})
 
   local location = util.get_lsp_location_from_selection()
-  local selected_text = util.get_selected_text()
+	local selected_text = ""
 
   if not selected then
     location = util.get_lsp_location_from_caret()
   else
+    selected_text = util.get_selected_text()
     if opts["matchSelected"] then
       opts = vim.tbl_extend("force", { match = { selected_text } }, opts or {})
     end


### PR DESCRIPTION
Fixes #273 #271 

Bug introduced in #270 

Solution here is to just call the character range selection, if range selection is set to true. It is not needed otherwise, and if it's called without a range selection, it errors and breaks.