### PR TITLE
Make fzf-lua show_note_picker() take multi_select into account.

### DIFF
--- a/lua/zk/pickers/fzf_lua.lua
+++ b/lua/zk/pickers/fzf_lua.lua
@@ -40,6 +40,7 @@ function M.show_note_picker(notes, options, cb)
       ["--with-nth"] = 2,
       ["--tabstop"] = 4,
       ["--header"] = ansi_codes.blue("CTRL-E: create a note with the query as title"),
+      ["--multi"] = options.multi_select,
     },
     -- we rely on `fzf-lua` to open notes in any other case than the default (pressing enter)
     -- to take advantage of the plugin builtin actions like opening in a split


### PR DESCRIPTION
Currently, the `show_note_picker()` function for the fzf-lua picker doesn't take into account the value of `multi_select`.