### PR TITLE
style: use opts with lazy.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,10 @@ Via [lazy.nvim](https://github.com/folke/lazy.nvim)
 ```lua
 {
   "zk-org/zk-nvim",
-  config = function()
-    require("zk").setup({
-      -- See Setup section below
-    })
-  end
+  name = "zk",
+  opts = {
+    -- See Setup section below
+  },
 }
 ```
 
@@ -60,34 +59,33 @@ Default `lazy.nvim` setup:
 ```lua
 return {
   "zk-org/zk-nvim",
-  config = function()
-    require("zk").setup({
-      -- Can be "telescope", "fzf", "fzf_lua", "minipick", "snacks_picker",
-      -- or select" (`vim.ui.select`).
-      picker = "select",
+  name = "zk",
+  opts = {
+    -- Can be "telescope", "fzf", "fzf_lua", "minipick", "snacks_picker",
+    -- or select" (`vim.ui.select`).
+    picker = "select",
 
-      lsp = {
-        -- `config` is passed to `vim.lsp.start(config)`
-        config = {
-          name = "zk",
-          cmd = { "zk", "lsp" },
-          filetypes = { "markdown" },
-          -- on_attach = ...
-          -- etc, see `:h vim.lsp.start()`
-        },
-
-        -- automatically attach buffers in a zk notebook that match the given filetypes
-        auto_attach = {
-          enabled = true,
-        },
+    lsp = {
+      -- `config` is passed to `vim.lsp.start(config)`
+      config = {
+        name = "zk",
+        cmd = { "zk", "lsp" },
+        filetypes = { "markdown" },
+        -- on_attach = ...
+        -- etc, see `:h vim.lsp.start()`
       },
-    })
-  end,
+
+      -- automatically attach buffers in a zk notebook that match the given filetypes
+      auto_attach = {
+        enabled = true,
+      },
+    },
+  },
 }
 ```
 
-Note that the `setup` function will not add any key mappings for you. If you
-want to add key mappings, see the [example mappings](#example-mappings).
+Note that this will not add any key mappings for you. If you want to add key
+mappings, see the [example mappings](#example-mappings).
 
 ### Picker Options
 
@@ -587,9 +585,8 @@ require("lazy").setup({
 	},
 	{
 		"zk-org/zk-nvim",
-		config = function()
-			require("zk").setup()
-		end,
+		name = "zk",
+		opts = {},
 	},
 	-- automatically check for plugin updates
 	checker = { enabled = true },

--- a/README.md
+++ b/README.md
@@ -149,21 +149,21 @@ see what they can do, and learn as you go.
 
 [Options (ZkIndex)](https://zk-org.github.io/zk/tips/editors-integration.html#zk-index)
 
-- `:ZkIndex [{options}]`  
+- `:ZkIndex [{options}]`\
   Indexes the notebook.
 
 ### Creating Notes
 
 [Options (ZkNew)](https://zk-org.github.io/zk/tips/editors-integration.html#zk-new)
 
-- `:ZkNew [{options}]`  
+- `:ZkNew [{options}]`\
   Creates and edits a new note.
 
-- `:'<,'>ZkNewFromTitleSelection [{options}]`  
+- `:'<,'>ZkNewFromTitleSelection [{options}]`\
   Creates a new note from the visual selection (used as the **title**) and
   replaces the selection with a link to the note.
 
-- `:'<,'>ZkNewFromContentSelection [{options}]`  
+- `:'<,'>ZkNewFromContentSelection [{options}]`\
   Creates a new note from the visual selection (used as the **content**) and
   replaces the selection with a link to the note.
 
@@ -171,29 +171,29 @@ see what they can do, and learn as you go.
 
 [Options (ZkList)](https://zk-org.github.io/zk/tips/editors-integration.html#zk-list)
 
-- `:ZkCd [{options}]`  
+- `:ZkCd [{options}]`\
   Changes directory to the notebook root.
 
-- `:ZkNotes [{options}]`  
+- `:ZkNotes [{options}]`\
   Opens a notes picker.
 
-- `:ZkBuffers [{options}]`  
+- `:ZkBuffers [{options}]`\
   Opens a notes picker for active buffers (notebook files only).
 
-- `:ZkBacklinks [{options}]`  
+- `:ZkBacklinks [{options}]`\
   Opens a notes picker showing backlinks of the current buffer.
 
-- `:ZkLinks [{options}]`  
+- `:ZkLinks [{options}]`\
   Opens a notes picker showing outbound links of the current buffer.
 
 ### Linking
 
 [Options (ZkList)](https://zk-org.github.io/zk/tips/editors-integration.html#zk-list)
 
-- `:ZkInsertLink`  
+- `:ZkInsertLink`\
   Inserts a link at the cursor location.
 
-- `:'<,'>ZkInsertLinkAtSelection [{options}]`  
+- `:'<,'>ZkInsertLinkAtSelection [{options}]`\
   Inserts a link around the selected text.
   - Special option: `matchSelected = true` → filters notes similar to the
     selection.
@@ -202,10 +202,10 @@ see what they can do, and learn as you go.
 
 [Options (ZkList)](https://zk-org.github.io/zk/tips/editors-integration.html#zk-list)
 
-- `:'<,'>ZkMatch [{options}]`  
+- `:'<,'>ZkMatch [{options}]`\
   Opens a notes picker, filtering for notes matching the visual selection.
 
-- `:ZkTags [{options}]`  
+- `:ZkTags [{options}]`\
   Opens a notes picker for selected tags.
 
 In addition, `options.notebook_path` can be used to explicitly specify a
@@ -580,13 +580,8 @@ vim.g.maplocalleader = "\\"
 
 -- Setup lazy.nvim
 require("lazy").setup({
-	{
-		"neovim/nvim-lspconfig",
-	},
-	{
-		"zk-org/zk-nvim",
-		name = "zk",
-		opts = {},
+	{ "neovim/nvim-lspconfig" },
+	{ "zk-org/zk-nvim", opts = {},
 	},
 	-- automatically check for plugin updates
 	checker = { enabled = true },
@@ -600,4 +595,3 @@ Then change this line in `.zk/config.toml`
 # editor = "vim"
 editor = "nvim -u ~/path/to/init-zk/init.lua"
 ```
-


### PR DESCRIPTION
This PR updates README.md to use `opts` table instead of a `config` function as [recommended by lazy.nvim](https://lazy.folke.io/developers#best-practices).

<img width="979" height="429" alt="image" src="https://github.com/user-attachments/assets/e1b8baad-5e59-41c0-a659-75256e9e4cea" />