### PR TITLE
Remove "note-count" from `ZkTags` sort options before passing to notes picker

### DIFF
--- a/lua/zk/commands/builtin.lua
+++ b/lua/zk/commands/builtin.lua
@@ -81,7 +81,7 @@ local function insert_link(selected, opts)
   opts = vim.tbl_extend("force", {}, opts or {})
 
   local location = util.get_lsp_location_from_selection()
-	local selected_text = ""
+  local selected_text = ""
 
   if not selected then
     location = util.get_lsp_location_from_caret()
@@ -128,6 +128,9 @@ commands.add("ZkTags", function(options)
     tags = vim.tbl_map(function(v)
       return v.name
     end, tags)
+    options.sort = vim.tbl_filter(function(v)
+      return string.find(v, "note-count[+-]?") ~= nil
+    end, options.sort)
     options = vim.tbl_extend("keep", { tags = tags }, options or {})
     zk.edit(options, { title = "Zk Notes for tag(s) " .. vim.inspect(tags) })
   end)

--- a/lua/zk/commands/builtin.lua
+++ b/lua/zk/commands/builtin.lua
@@ -123,14 +123,24 @@ commands.add("ZkMatch", function(options)
   zk.edit(options, { title = "Zk Notes matching " .. vim.inspect(selected_text) })
 end, { needs_selection = true })
 
+-- List of tag specific search terms, which need to be later ignored.
+-- https://zk-org.github.io/zk/tips/editors-integration.html#zk-tag-list
+-- https://github.com/zk-org/zk-nvim/pull/290
+local search_terms = { "name", "note-count" }
+
 commands.add("ZkTags", function(options)
   zk.pick_tags(options, { title = "Zk Tags" }, function(tags)
     tags = vim.tbl_map(function(v)
       return v.name
     end, tags)
+
+		-- Don't pass on tag specific search terms to subsequent call to sort.
     options.sort = vim.tbl_filter(function(v)
-      return string.find(v, "note-count[+-]?") ~= nil
+      return not vim.iter(search_terms):any(function(term)
+        return vim.startswith(v, term)
+      end)
     end, options.sort)
+
     options = vim.tbl_extend("keep", { tags = tags }, options or {})
     zk.edit(options, { title = "Zk Notes for tag(s) " .. vim.inspect(tags) })
   end)


### PR DESCRIPTION
I found that using `ZkTags {sort = {"note-count"}}` gives an error once a tag is selected because the arguments in `options.sort` are immediately passed to `zk.edit`. However, the `"note-count"` argument can't be used to sort notes. According to [zk docs](https://zk-org.github.io/zk/tips/editors-integration.html#zk-tag-list), `name` and `note-count` are the only allowed arguments, so I considered it safe to simply remove `note-count`.

More broadly, I think this is related to what I consider a shortcoming in using `ZkTags` to search for notes. From my understanding, there's no way to explicitly pass separate tables of search options (i.e., one for the tags picker and one for the subsequent notes picker). A while ago I was playing around with a custom command that internally handles this; nothing fancy, just pulling out `note-count` similar to what I've done here. Not sure if you consider such functionality useful.