### PR TITLE
Only filter ZkTags sort options if present

### DIFF
--- a/lua/zk/commands/builtin.lua
+++ b/lua/zk/commands/builtin.lua
@@ -130,12 +130,14 @@ commands.add("ZkTags", function(options)
       return v.name
     end, tags)
 
-		-- Don't pass on tag specific search terms to subsequent call to sort.
-    options.sort = vim.tbl_filter(function(v)
-      return not vim.iter(search_terms):any(function(term)
-        return vim.startswith(v, term)
-      end)
-    end, options.sort)
+    -- Don't pass on tag specific search terms to subsequent call to sort.
+    if options and options.sort then
+      options.sort = vim.tbl_filter(function(v)
+        return not vim.iter(search_terms):any(function(term)
+          return vim.startswith(v, term)
+        end)
+      end, options.sort)
+    end
 
     options = vim.tbl_extend("keep", { tags = tags }, options or {})
     zk.edit(options, { title = "Zk Notes for tag(s) " .. vim.inspect(tags) })


### PR DESCRIPTION
#290 introduced a bug with `ZkTags` because the `options.sort` filtering was happening regardless of whether `options` or `options.sort` given. I must have only tested out the result when passing sort options to `ZkTags` and not a bare `ZkTags` call.