### PR TITLE
Add ability to combine target tags with OR

### DIFF
--- a/lua/zk/commands/builtin.lua
+++ b/lua/zk/commands/builtin.lua
@@ -139,6 +139,10 @@ commands.add("ZkTags", function(options)
       end, options.sort)
     end
 
+    if options and options.use_or then
+      tags = { table.concat(tags, " OR ") }
+    end
+
     options = vim.tbl_extend("keep", { tags = tags }, options or {})
     zk.edit(options, { title = "Zk Notes for tag(s) " .. vim.inspect(tags) })
   end)


### PR DESCRIPTION
I realized that you can combine tags during a `ZkTags` search with an `"OR"` conjunction. The implicit default behavior appears to be `"AND"`. What do you think of introducing this option `options.use_or = true` (boolean) to the `ZkTags` command? Maybe this risks conflicts with other commands that don't use such an option (i.e., like the sort options issue in #290)? Or, maybe this needs to be done in parallel with changes in `zk`, not just `zk-nvim`?

This [issue](https://github.com/zk-org/zk/issues/722) has a similar sentiment.