### PR TITLE
Add multi_select_strategy option for configuring how multiple tags are treated during search

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ return {
         enabled = true,
       },
     },
+
+    tags = {
+      -- Configure how multiple tags should be combined in a ZkTags search
+      -- Can be "AND" or "OR"
+      multi_select_strategy = "AND",
+    }
   },
 }
 ```

--- a/lua/zk/commands/builtin.lua
+++ b/lua/zk/commands/builtin.lua
@@ -2,6 +2,7 @@ local zk = require("zk")
 local api = require("zk.api")
 local util = require("zk.util")
 local commands = require("zk.commands")
+local config = require("zk.config")
 
 commands.add("ZkIndex", zk.index)
 
@@ -130,6 +131,12 @@ commands.add("ZkTags", function(options)
       return v.name
     end, tags)
 
+    local sep = config.options.tags.multi_select_strategy
+    if options and options.multi_select_strategy then
+      sep = options.multi_select_strategy
+    end
+    local tag_query = table.concat(tags, " " .. sep .. " ")
+
     -- Don't pass on tag specific search terms to subsequent call to sort.
     if options and options.sort then
       options.sort = vim.tbl_filter(function(v)
@@ -139,7 +146,7 @@ commands.add("ZkTags", function(options)
       end, options.sort)
     end
 
-    options = vim.tbl_extend("keep", { tags = tags }, options or {})
-    zk.edit(options, { title = "Zk Notes for tag(s) " .. vim.inspect(tags) })
+    options = vim.tbl_extend("keep", { tags = { tag_query } }, options or {})
+    zk.edit(options, { title = "Zk Notes for tag(s) " .. vim.inspect(tags) .. " using " .. sep })
   end)
 end)

--- a/lua/zk/config.lua
+++ b/lua/zk/config.lua
@@ -13,6 +13,9 @@ M.defaults = {
       enabled = true,
     },
   },
+  tags = {
+    multi_select_strategy = "AND",
+  },
 }
 
 M.options = M.defaults -- not necessary, but better code completion


### PR DESCRIPTION
See #293 for origin/context.

- Adds plugin config `tags.multi_select_strategy` option that defaults to `"AND"`
- Uses strategy given by options when `ZkTags` used. Otherwise, falls back to plugin config.
- Instead of specifying tags as a table of tags, I standardized by always converting the table of tags to a "query" string using the specified separator (`"AND"` or `"OR"`).
- Also display the chosen separator in the notes picker prompt
- Adds option to default `lazy.nvim` config example in README