### PR TITLE
Fix ZkBuffers not showing all buffers when opening multiple notes from the CLI

### DIFF
--- a/lua/zk/util.lua
+++ b/lua/zk/util.lua
@@ -5,10 +5,10 @@ local M = {}
 ---@param notebook_path string
 ---@return string? root
 function M.notebook_root(notebook_path)
-  local root_pattern = require("zk.root_pattern_util").root_pattern(".zk")
-  local rp = root_pattern(notebook_path)
-  return rp
-  -- return require("zk.root_pattern_util").root_pattern(".zk")(notebook_path)
+	local root_pattern = require("zk.root_pattern_util").root_pattern(".zk")
+	local rp = root_pattern(notebook_path)
+	return rp
+	-- return require("zk.root_pattern_util").root_pattern(".zk")(notebook_path)
 end
 
 ---Try to resolve a notebook path by checking the following locations in that order
@@ -21,56 +21,56 @@ end
 ---@param bufnr number?
 ---@return string? path inside a notebook
 function M.resolve_notebook_path(bufnr)
-  local path = vim.api.nvim_buf_get_name(bufnr)
-  local cwd = vim.fn.getcwd(0)
-  -- if the buffer has no name (i.e. it is empty), set the current working directory as it's path
-  if path == "" then
-    path = cwd
-  end
-  if not M.notebook_root(path) then
-    if not M.notebook_root(cwd) then
-      -- if neither the buffer nor the cwd belong to a notebook, use $ZK_NOTEBOOK_DIR as fallback if available
-      if vim.env.ZK_NOTEBOOK_DIR then
-        path = vim.env.ZK_NOTEBOOK_DIR
-      end
-    else
-      -- the buffer doesn't belong to a notebook, but the cwd does!
-      path = cwd
-    end
-  end
-  -- at this point, the buffer either belongs to a notebook, or everything else failed
-  return path
+	local path = vim.api.nvim_buf_get_name(bufnr)
+	local cwd = vim.fn.getcwd(0)
+	-- if the buffer has no name (i.e. it is empty), set the current working directory as it's path
+	if path == "" then
+		path = cwd
+	end
+	if not M.notebook_root(path) then
+		if not M.notebook_root(cwd) then
+			-- if neither the buffer nor the cwd belong to a notebook, use $ZK_NOTEBOOK_DIR as fallback if available
+			if vim.env.ZK_NOTEBOOK_DIR then
+				path = vim.env.ZK_NOTEBOOK_DIR
+			end
+		else
+			-- the buffer doesn't belong to a notebook, but the cwd does!
+			path = cwd
+		end
+	end
+	-- at this point, the buffer either belongs to a notebook, or everything else failed
+	return path
 end
 
 local function get_offset_encoding(bufnr)
-  -- Modified from nvim's vim.lsp.util._get_offset_encoding()
-  vim.validate("bufnr", bufnr, "number", true)
-  local zk_client = vim.lsp.get_clients({ bufnr = bufnr, name = "zk" })[1]
-  local error_level = vim.log.levels.ERROR
-  local offset_encoding --- @type 'utf-8'|'utf-16'|'utf-32'
-  if zk_client == nil then
-    vim.notify_once("No zk client found for this buffer. Falling back to default (utf-16)", error_level)
-    offset_encoding = "utf-16"
-  elseif zk_client.offset_encoding == nil then
-    vim.notify_once(
-      string.format(
-        "ZK Client (id: %s) offset_encoding is nil. Falling back to default (utf-16).",
-        zk_client.id
-      ),
-      error_level
-    )
-    offset_encoding = "utf-16"
-  else
-    offset_encoding = zk_client.offset_encoding
-  end
-  return offset_encoding
+	-- Modified from nvim's vim.lsp.util._get_offset_encoding()
+	vim.validate("bufnr", bufnr, "number", true)
+	local zk_client = vim.lsp.get_clients({ bufnr = bufnr, name = "zk" })[1]
+	local error_level = vim.log.levels.ERROR
+	local offset_encoding --- @type 'utf-8'|'utf-16'|'utf-32'
+	if zk_client == nil then
+		vim.notify_once("No zk client found for this buffer. Falling back to default (utf-16)", error_level)
+		offset_encoding = "utf-16"
+	elseif zk_client.offset_encoding == nil then
+		vim.notify_once(
+			string.format(
+				"ZK Client (id: %s) offset_encoding is nil. Falling back to default (utf-16).",
+				zk_client.id
+			),
+			error_level
+		)
+		offset_encoding = "utf-16"
+	else
+		offset_encoding = zk_client.offset_encoding
+	end
+	return offset_encoding
 end
 
 local function make_range_zk()
-  local bufnr = vim.api.nvim_get_current_buf()
-  local offset_encoding = get_offset_encoding(bufnr)
-  -- This function has a warning if encoding is not passed
-  return vim.lsp.util.make_given_range_params(nil, nil, bufnr, offset_encoding)
+	local bufnr = vim.api.nvim_get_current_buf()
+	local offset_encoding = get_offset_encoding(bufnr)
+	-- This function has a warning if encoding is not passed
+	return vim.lsp.util.make_given_range_params(nil, nil, bufnr, offset_encoding)
 end
 
 ---Makes an LSP location object from the last selection in the current buffer.
@@ -78,11 +78,11 @@ end
 ---@return table LSP location object
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#location
 function M.get_lsp_location_from_selection()
-  local params = make_range_zk()
-  return {
-    uri = params.textDocument.uri,
-    range = params.range,
-  }
+	local params = make_range_zk()
+	return {
+		uri = params.textDocument.uri,
+		range = params.range,
+	}
 end
 
 ---Fix to correct cursor location
@@ -94,17 +94,17 @@ end
 ---@return table The LSP location corrected one row up and one column right
 ---@internal
 local function fix_cursor_location(location)
-  -- Cursor LSP position is a little weird.
-  -- It inserts one line down. Seems like an off by one error somewhere
-  local pos = location["range"]["start"]
+	-- Cursor LSP position is a little weird.
+	-- It inserts one line down. Seems like an off by one error somewhere
+	local pos = location["range"]["start"]
 
-  pos["line"] = pos["line"] - 1
-  pos["character"] = pos["character"] + 1
+	pos["line"] = pos["line"] - 1
+	pos["character"] = pos["character"] + 1
 
-  location["range"]["start"] = pos
-  location["range"]["end"] = pos
+	location["range"]["start"] = pos
+	location["range"]["end"] = pos
 
-  return location
+	return location
 end
 
 ---Makes an LSP location object from the caret position in the current buffer.
@@ -112,58 +112,58 @@ end
 ---@return table LSP location object
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#location
 function M.get_lsp_location_from_caret()
-  local params = make_range_zk()
+	local params = make_range_zk()
 
-  local row, col = unpack(vim.api.nvim_win_get_cursor(0))
-  local position = { line = row, character = col }
-  return fix_cursor_location({
-    uri = params.textDocument.uri,
-    range = {
-      start = position,
-      ["end"] = position,
-    },
-  })
+	local row, col = unpack(vim.api.nvim_win_get_cursor(0))
+	local position = { line = row, character = col }
+	return fix_cursor_location({
+		uri = params.textDocument.uri,
+		range = {
+			start = position,
+			["end"] = position,
+		},
+	})
 end
 
 ---Gets the text in the last visual selection.
 --
 ---@return string text in range
 function M.get_selected_text()
-  local region = vim.fn.getregionpos(vim.fn.getpos("'<"), vim.fn.getpos("'>"), { exclusive = false })
+	local region = vim.fn.getregionpos(vim.fn.getpos("'<"), vim.fn.getpos("'>"), { exclusive = false })
 
-  local chunks = {}
-  local maxcol = vim.v.maxcol
-  for _, segment in ipairs(region) do
-    -- each segment is two positions: start and end
-    local start_pos, end_pos = segment[1], segment[2]
-    -- buffer and line don't change between start and end -> use start only
-    -- Note getregionpos returns 1-based indexing, but get_text expects 0-based
-    local bufnr, line = start_pos[1], start_pos[2] - 1
-    local startcol = start_pos[3] - 1
-    local endcol = end_pos[3] -- 0-indexing, but we want to include the last col so
-    endcol = endcol == maxcol and -1 or endcol
-    local chunk = vim.api.nvim_buf_get_text(bufnr, line, startcol, line, endcol, {})[1]
-    table.insert(chunks, chunk)
-  end
-  return table.concat(chunks, "\n")
+	local chunks = {}
+	local maxcol = vim.v.maxcol
+	for _, segment in ipairs(region) do
+		-- each segment is two positions: start and end
+		local start_pos, end_pos = segment[1], segment[2]
+		-- buffer and line don't change between start and end -> use start only
+		-- Note getregionpos returns 1-based indexing, but get_text expects 0-based
+		local bufnr, line = start_pos[1], start_pos[2] - 1
+		local startcol = start_pos[3] - 1
+		local endcol = end_pos[3] -- 0-indexing, but we want to include the last col so
+		endcol = endcol == maxcol and -1 or endcol
+		local chunk = vim.api.nvim_buf_get_text(bufnr, line, startcol, line, endcol, {})[1]
+		table.insert(chunks, chunk)
+	end
+	return table.concat(chunks, "\n")
 end
 
----Gets the file paths of active buffers.
+---Gets the file paths of all buffers that have valid paths.
 --
----@return table Paths of currently active buffers.
+---@return table Paths of all buffers that have valid paths.
 function M.get_buffer_paths()
-  local buffers = vim.api.nvim_list_bufs()
-  local paths = {}
+	local buffers = vim.api.nvim_list_bufs()
+	local paths = {}
 
-  for _, buf in ipairs(buffers) do
-    local path = vim.api.nvim_buf_get_name(buf)
+	for _, buf in ipairs(buffers) do
+		local path = vim.api.nvim_buf_get_name(buf)
 
-    if vim.api.nvim_buf_is_loaded(buf) and path ~= "" then
-      table.insert(paths, path)
-    end
-  end
+		if path ~= "" then
+			table.insert(paths, path)
+		end
+	end
 
-  return paths
+	return paths
 end
 
 return M


### PR DESCRIPTION
The util function returned active buffers only, which meant all other notes that
were opened from the CLI apart from the note immediately rendered (and therefore
set as an active buffer), were not shown by `ZkBuffers`. 

This is not a good implementation for the util function. It now only returns
buffers with valid paths (i.e., it won't return empty buffers). 

The util function was until now only used by `ZkBuffers`.
