### PR TITLE
remove free text search term arguments from ZkMatch 

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,15 +210,12 @@ see what they can do, and learn as you go.
 
 [Options (ZkList)](https://zk-org.github.io/zk/tips/editors-integration.html#zk-list)
 
-- `:ZkMatch [{options}] [{term}]`\
+- `:ZkMatch [{options}]`\
   Opens a notes picker, filtering for notes matching a search term. The term
-  is resolved in this priority order: an explicit `options.match`, free-text
-  arguments (no quotes needed, e.g. `:ZkMatch my search term`), a visual
-  selection (`:'<,'>ZkMatch`), or — in normal mode with no arguments — the
-  word under the cursor. An `{options}` table (e.g. for `sort`) can be
-  combined with trailing free text, e.g. `:ZkMatch {created_before =
-  "2026-08-24"} my search term`; if it omits a `match` field, the term falls
-  back through free-text/selection/cursor-word as above.
+  is resolved from, in priority order: an explicit `options.match` (see the
+  `match` option in [Options (ZkList)](https://zk-org.github.io/zk/tips/editors-integration.html#zk-list)),
+  a visual selection (`:'<,'>ZkMatch`), or — in normal mode — the word under
+  the cursor.
 
 - `:ZkTags [{options}]`\
   Opens a notes picker for selected tags.
@@ -234,9 +231,8 @@ _Examples:_
 :ZkNotes { createdAfter = "3 days ago", tags = { "work" } }
 :'<,'>ZkNewFromTitleSelection " this will use your last visual mode selection. Note that you *must* call this command with the '<,'> range.
 :ZkCd
-:ZkMatch foo bar baz " free-text search, no quotes needed
-:ZkMatch { sort = { "created" } } " options table; falls back to selection/cursor word for the match term
-:ZkMatch {created_before = "2026-08-24"} foo bar " options table combined with free-text match term
+:ZkMatch { match = { "foo", "bar" } } " search notes matching "foo" or "bar"
+:ZkMatch { sort = { "created" } } " no match given, falls back to the word under the cursor (or visual selection)
 ```
 
 ---

--- a/lua/zk/commands/builtin.lua
+++ b/lua/zk/commands/builtin.lua
@@ -113,78 +113,31 @@ commands.add("ZkInsertLinkAtSelection", function(opts)
 	insert_link(true, opts)
 end, { title = "Insert Zk link", needs_selection = true })
 
----Splits a leading balanced `{...}` Lua table literal off the front of
----`text`, returning the table-literal substring and the remaining text after
----it (trimmed). Returns nil for the table string if `text` doesn't start
----with a balanced `{...}` (e.g. unbalanced braces).
----@param text string
----@return string? table_str
----@return string remainder
-local function split_leading_table(text)
-	local brace_depth = 0
-	local string_quote_char = nil
-	local position = 1
-	local text_length = #text
-	while position <= text_length do
-		local current_char = text:sub(position, position)
-		if string_quote_char then
-			if current_char == "\\" then
-				position = position + 1
-			elseif current_char == string_quote_char then
-				string_quote_char = nil
-			end
-		elseif current_char == '"' or current_char == "'" then
-			string_quote_char = current_char
-		elseif current_char == "{" then
-			brace_depth = brace_depth + 1
-		elseif current_char == "}" then
-			brace_depth = brace_depth - 1
-			if brace_depth == 0 then
-				return text:sub(1, position), vim.trim(text:sub(position + 1))
-			end
-		end
-		position = position + 1
-	end
-	return nil, text
-end
-
--- Matches against provided search terms, word under cursor (normal mode) and visual selection.
--- Can also be combined with options, e.g. `:ZkMatch {tags = {"scienece"}} search terms`.
--- Priority: options.match > free-text args > visual selection > word under cursor.
-commands.add("ZkMatch", function(args, range)
-	local trimmed = vim.trim(args)
-	local options = {}
-	local remainder = trimmed
-
-	if vim.startswith(trimmed, "{") then
-		local options_str, rest = split_leading_table(trimmed)
-		local chunk = options_str and loadstring("return " .. options_str)
-		assert(chunk ~= nil, "Malformed {options} table given to :ZkMatch")
-		options = chunk() or {}
-		remainder = rest
-	end
+-- Matches against the provided options (which may include a `match` field
+-- - see https://zk-org.github.io/zk/tips/editors-integration.html#zk-list),
+-- a visual selection, or (in normal mode with no selection) the word under
+-- the cursor. `options.match`, if given, takes priority over the selection
+-- or cursor word.
+commands.add("ZkMatch", function(options, range)
+	options = options or {}
 
 	if not options.match then
 		local match_text
-		if remainder ~= "" then
-			match_text = remainder
-		elseif range == 2 then
+		if range == 2 then
 			match_text = util.get_selected_text()
-		end
-		if not match_text then
+		else
 			local cword = vim.fn.expand("<cword>")
 			match_text = cword ~= "" and cword or nil
 		end
 		assert(
 			match_text ~= nil,
-			"No selected text, search term, or word under cursor given. Usage: :ZkMatch <term> or visually select text."
+			"No selected text or word under cursor given. Usage: :'<,'>ZkMatch or place the cursor on a word."
 		)
 		options.match = { match_text }
 	end
 
-	local title_text = table.concat(options.match, ", ")
-	zk.edit(options, { title = "Zk Notes matching " .. vim.inspect(title_text) })
-end, { raw_args = true, optional_selection = true })
+	zk.edit(options, { title = "Zk Notes matching " .. vim.inspect(options.match) })
+end, { optional_selection = true })
 
 -- List of tag specific search terms, which need to be later ignored.
 -- https://zk-org.github.io/zk/tips/editors-integration.html#zk-tag-list

--- a/lua/zk/commands/init.lua
+++ b/lua/zk/commands/init.lua
@@ -3,13 +3,12 @@ local M = {}
 local name_fn_map = {}
 
 ---A thin wrapper around `vim.api.nvim_create_user_command` which parses
----the `params.args` of the command as a Lua table and passes it on to `fn`.
+---the `params.args` of the command as a Lua table and passes it on to `fn`,
+---along with `params.range`.
 ---@param name string
 ---@param fn function
 ---@param opts? table {needs_selection} makes sure the command is called with a range.
 ---{optional_selection} allows (but doesn't require) the command to be called with a range.
----{raw_args} passes `params.args` (the raw, unparsed argument string) and `params.range`
----to `fn` directly instead of `loadstring`-parsing `params.args` as a Lua table.
 ---@see vim.api.nvim_create_user_command
 function M.add(name, fn, opts)
   opts = opts or {}
@@ -20,16 +19,12 @@ function M.add(name, fn, opts)
         "Command needs a selection and must be called with '<,'> range. Try making a selection first."
       )
     end
-    if opts.raw_args then
-      fn(params.args, params.range)
-    else
-      fn(loadstring("return " .. params.args)())
-    end
+    fn(loadstring("return " .. params.args)(), params.range)
   end, {
     nargs = "?",
     force = true,
     range = opts.needs_selection or opts.optional_selection,
-    complete = opts.raw_args and nil or "lua",
+    complete = "lua",
   })
   name_fn_map[name] = fn
 end


### PR DESCRIPTION
Removes the ability to pass free text arguments to `ZkMatch`, which was
introduced in #298. This meant that a custom options table stripper had to be
implemented, which created unnecessary code bloat. 

Search terms should instead just be passed to the options table directly like
normal. A user can build a convenience keybind around ZkMatch for search term
entry to make this simpler and quicker if desired.

Running ZkMatch in normal mode with the cursor on a word, will still however 
use the word as input to ZkMatch. 
